### PR TITLE
CPU: fused gate/up FP8 quant 9.7-13.4x, worker-width fix 8.3x on decode, and a measured NUMA negative

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,38 @@ jq -r .network "$ASSETS/weights.json"
 Streaming: `"stream": true`. Also `/healthz`, `/metrics`. Multiple
 `--assets DIR` register more models.
 
-For CPU-only builds, AVX-512 coverage, and NUMA placement, see
-[CPU execution](docs/runtime/cpu.md).
+## CPU-only (no GPU)
+
+Same three steps, minus the interpreter objects — the CPU backend interprets the
+packet directly, so **step 2 is skipped entirely** and nothing links CUDA or HSA:
+
+```bash
+# 1. Build. --no-default-features drops the GPU backends.
+cargo build --release -p plowc
+cargo build --release -p plowrt --no-default-features --features cpu
+
+# 2. Compile the packet. plowc always emits for a device target; pick an NVIDIA
+#    one — an AMD gfx942/gfx950 packet does NOT load on the CPU backend.
+CKPT="$HOME/models/gemma-4-12B-it"
+./target/release/plowc --hf-dir "$CKPT" \
+  --gpu rtx6000pro --n-cu 96 --max-ctx 2048 \
+  --batch 1,4 --seq 128,512 --out "$ASSETS"
+
+# 3. Serve. --rt-checkpoint is required; the bundle carries no weights.
+./target/release/plowrt serve --assets "$ASSETS" --rt-checkpoint "$CKPT" \
+  --cpu-isa avx512 --cpu-numa auto
+```
+
+`--n-cu` sets the packet's *virtual* executor count, not a thread count: the
+worker pool maps any number of threads onto it, so one bundle serves any core
+count and `--cpu-threads` is free to differ. Compile once at a width that divides
+the largest machine you intend to serve (the emitter caps it at 256).
+
+Runtime knobs are all `--cpu-*` (`--cpu-threads`, `--cpu-numa`, `--cpu-isa`,
+`--cpu-spin-us`, …), each with a `PLOW_CPU_*` env twin — full table in
+[CPU execution](docs/runtime/cpu.md#flags), which also covers AVX-512/AMX
+coverage, NUMA policy, and the two A/B knobs that are off because they measured
+slower.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -233,8 +233,9 @@ CKPT="$HOME/models/gemma-4-12B-it"
 
 `--n-cu` sets the packet's *virtual* executor count, not a thread count: the
 worker pool maps any number of threads onto it, so one bundle serves any core
-count and `--cpu-threads` is free to differ. Compile once at a width that divides
-the largest machine you intend to serve (the emitter caps it at 256).
+count. Fewer threads than executors is fine; more is wasteful, so the automatic
+worker width caps itself at `--n-cu`. Compile once at a width that divides the
+largest machine you intend to serve (the emitter caps it at 256).
 
 Runtime knobs are all `--cpu-*` (`--cpu-threads`, `--cpu-numa`, `--cpu-isa`,
 `--cpu-spin-us`, …), each with a `PLOW_CPU_*` env twin — full table in

--- a/crates/plowrt/examples/l2_probe.rs
+++ b/crates/plowrt/examples/l2_probe.rs
@@ -1,15 +1,22 @@
-//! What locality a devblob carries, and how it lands on this host's NUMA nodes.
+//! What locality a devblob carries, and what the runtime actually does with it.
 //!
 //! `cargo run --example l2_probe -- model.pkt [nodes]`
 //!
-//! Reports each program's declared L2 domain count and the cu -> domain map recovered from the
-//! per-entry domain bits, then the node split `exec::cpu::engine::node_plan` would choose. Use it
-//! to tell a placed blob from an unplaced one before attributing a measurement to placement.
+//! Reports each program's declared L2 domain count, the cu -> domain map recovered from the
+//! per-entry domain bits, the candidate node split, and then the decision the runtime reaches on
+//! it. Candidate and accepted are separate lines on purpose: a mapping can divide cleanly over the
+//! nodes and still be refused for leaving a node busier than `cu % nodes` would, which is the
+//! common outcome. Use it to tell a placed blob from an unplaced one, and an accepted plan from a
+//! merely well-formed one, before attributing a measurement to placement.
+//!
+//! Domain recovery and the decision come from `exec::cpu::engine` itself rather than a copy here,
+//! so this can never drift from what the engine does.
 
 use std::collections::BTreeMap;
 
 use packet::dev::{SE_DOMAIN_MASK, SE_DOMAIN_SHIFT};
 use plowrt::asset::devblob::DevBlob;
+use plowrt::exec::cpu::engine::{cu_domains, cu_work, node_plan};
 
 fn main() {
     let mut args = std::env::args().skip(1);
@@ -17,14 +24,9 @@ fn main() {
     let nodes: usize = args.next().map_or(8, |a| a.parse().expect("nodes"));
     let buf = std::fs::read(&path).expect("read blob");
     let blob = DevBlob::parse_l2(&buf, true).expect("parse blob");
-    println!(
-        "n_cu={} progs={} nodes={nodes}",
-        blob.n_cu,
-        blob.progs.len()
-    );
+    let n_cu = blob.n_cu;
+    println!("n_cu={n_cu} progs={} nodes={nodes}", blob.progs.len());
 
-    let mut cu_dom: Vec<u32> = vec![u32::MAX; blob.n_cu as usize];
-    let mut domains = 0u32;
     for (pi, p) in blob.progs.iter().enumerate() {
         let mut seen: BTreeMap<u32, usize> = BTreeMap::new();
         for e in &p.stream {
@@ -40,66 +42,58 @@ fn main() {
             p.gq_seg_ofs.len().saturating_sub(1),
             seen.keys().collect::<Vec<_>>()
         );
-        if p.l2_domains == 0 {
-            continue;
-        }
-        domains = p.l2_domains;
-        for (cu, slot) in cu_dom.iter_mut().enumerate() {
-            let start = p.stream_ofs[cu] as usize;
-            for e in &p.stream[start..start + p.stream_len[cu] as usize] {
-                let d = ((e.flags & SE_DOMAIN_MASK) >> SE_DOMAIN_SHIFT) as u32;
-                if *slot != u32::MAX && *slot != d {
-                    println!("  !! cu {cu} carries domains {slot} and {d}");
-                }
-                *slot = d;
-            }
-        }
-    }
-    if domains == 0 {
-        println!("UNPLACED: no program declares L2 domains; placement stays cu % nodes");
-        return;
     }
 
+    let Some((cu_dom, domains)) = cu_domains(&blob.progs, n_cu) else {
+        println!("\nUNPLACED: no usable domain map; placement stays cu % nodes");
+        return;
+    };
     let mut per_domain = vec![0usize; domains as usize];
-    for &d in cu_dom.iter().filter(|&&d| d != u32::MAX) {
+    for &d in &cu_dom {
         per_domain[d as usize] += 1;
     }
-    println!("cus per domain: {per_domain:?}");
-    let head: Vec<u32> = cu_dom.iter().take(16).copied().collect();
-    println!("cu -> domain (first 16): {head:?}");
+    println!("\ncus per domain: {per_domain:?}");
+    println!(
+        "cu -> domain (first 16): {:?}",
+        cu_dom.iter().take(16).collect::<Vec<_>>()
+    );
 
     if !(domains as usize >= nodes && (domains as usize).is_multiple_of(nodes)) {
-        println!("PLACED but {domains} domains do not divide over {nodes} nodes: falls back to cu % nodes");
+        println!("CANDIDATE: none — {domains} domains do not divide over {nodes} nodes");
+        println!("ACCEPTED:  no, placement stays cu % nodes");
         return;
     }
     let per = domains as usize / nodes;
     let mut cus_per_node = vec![0usize; nodes];
-    for &d in cu_dom.iter().filter(|&&d| d != u32::MAX) {
+    for &d in &cu_dom {
         cus_per_node[d as usize / per] += 1;
     }
-    println!("PLACED: {domains} domains / {nodes} nodes = {per} per node, cus per node: {cus_per_node:?}");
+    println!("CANDIDATE: {domains} domains / {nodes} nodes = {per} per node, cus per node: {cus_per_node:?}");
 
-    // What each node actually has to RUN. Stream entries per cu is the work unit the static
-    // walk executes, and the makespan is set by the busiest node, so this is the number that
-    // decides whether a locality plan costs more than it can buy.
+    // What each node actually has to RUN, per program — programs are alternatives, so each one's
+    // own busiest node is its own makespan and the guard has to hold for every one separately.
+    let work = cu_work(&blob.progs, n_cu);
+    let accepted = node_plan(&cu_dom, domains, nodes, &work).is_some();
     println!("\nwork per node (stream entries), busiest node sets the makespan:");
-    for (pi, p) in blob.progs.iter().enumerate() {
-        let (mut placed, mut rr) = (vec![0usize; nodes], vec![0usize; nodes]);
-        for cu in 0..blob.n_cu as usize {
-            let n = p.stream_len[cu] as usize;
-            if cu_dom[cu] != u32::MAX {
-                placed[cu_dom[cu] as usize / per] += n;
-            }
+    for (pi, (p, w)) in blob.progs.iter().zip(&work).enumerate() {
+        let (mut placed, mut rr) = (vec![0u64; nodes], vec![0u64; nodes]);
+        for (cu, &n) in w.iter().enumerate() {
+            placed[cu_dom[cu] as usize / per] += n;
             rr[cu % nodes] += n;
         }
-        let ratio =
-            |v: &[usize]| *v.iter().max().unwrap() as f64 / *v.iter().min().unwrap().max(&1) as f64;
+        let (pmax, rmax) = (*placed.iter().max().unwrap(), *rr.iter().max().unwrap());
         println!(
-            "  prog[{pi}] T={:<5} placed max/min {:.2}x {placed:?}\n              {:11} round-robin max/min {:.2}x {rr:?}",
+            "  prog[{pi}] T={:<5} peak placed {pmax} vs round-robin {rmax}  {}\n    placed      {placed:?}\n    round-robin {rr:?}",
             p.t,
-            ratio(&placed),
-            "",
-            ratio(&rr)
+            if pmax <= rmax { "ok" } else { "WORSE — declines the plan" }
         );
     }
+    println!(
+        "\nACCEPTED:  {}",
+        if accepted {
+            "yes — the runtime places by domain (with --cpu-l2-place, which is off by default)"
+        } else {
+            "no — the guard refuses it; placement stays cu % nodes even with --cpu-l2-place"
+        }
+    );
 }

--- a/crates/plowrt/examples/l2_probe.rs
+++ b/crates/plowrt/examples/l2_probe.rs
@@ -1,0 +1,105 @@
+//! What locality a devblob carries, and how it lands on this host's NUMA nodes.
+//!
+//! `cargo run --example l2_probe -- model.pkt [nodes]`
+//!
+//! Reports each program's declared L2 domain count and the cu -> domain map recovered from the
+//! per-entry domain bits, then the node split `exec::cpu::engine::node_plan` would choose. Use it
+//! to tell a placed blob from an unplaced one before attributing a measurement to placement.
+
+use std::collections::BTreeMap;
+
+use packet::dev::{SE_DOMAIN_MASK, SE_DOMAIN_SHIFT};
+use plowrt::asset::devblob::DevBlob;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("usage: l2_probe <model.pkt> [nodes]");
+    let nodes: usize = args.next().map_or(8, |a| a.parse().expect("nodes"));
+    let buf = std::fs::read(&path).expect("read blob");
+    let blob = DevBlob::parse_l2(&buf, true).expect("parse blob");
+    println!(
+        "n_cu={} progs={} nodes={nodes}",
+        blob.n_cu,
+        blob.progs.len()
+    );
+
+    let mut cu_dom: Vec<u32> = vec![u32::MAX; blob.n_cu as usize];
+    let mut domains = 0u32;
+    for (pi, p) in blob.progs.iter().enumerate() {
+        let mut seen: BTreeMap<u32, usize> = BTreeMap::new();
+        for e in &p.stream {
+            *seen
+                .entry(((e.flags & SE_DOMAIN_MASK) >> SE_DOMAIN_SHIFT) as u32)
+                .or_default() += 1;
+        }
+        println!(
+            "  prog[{pi}] T={} l2_domains={} stream={} gq_windows={} distinct_domain_bits={:?}",
+            p.t,
+            p.l2_domains,
+            p.stream.len(),
+            p.gq_seg_ofs.len().saturating_sub(1),
+            seen.keys().collect::<Vec<_>>()
+        );
+        if p.l2_domains == 0 {
+            continue;
+        }
+        domains = p.l2_domains;
+        for (cu, slot) in cu_dom.iter_mut().enumerate() {
+            let start = p.stream_ofs[cu] as usize;
+            for e in &p.stream[start..start + p.stream_len[cu] as usize] {
+                let d = ((e.flags & SE_DOMAIN_MASK) >> SE_DOMAIN_SHIFT) as u32;
+                if *slot != u32::MAX && *slot != d {
+                    println!("  !! cu {cu} carries domains {slot} and {d}");
+                }
+                *slot = d;
+            }
+        }
+    }
+    if domains == 0 {
+        println!("UNPLACED: no program declares L2 domains; placement stays cu % nodes");
+        return;
+    }
+
+    let mut per_domain = vec![0usize; domains as usize];
+    for &d in cu_dom.iter().filter(|&&d| d != u32::MAX) {
+        per_domain[d as usize] += 1;
+    }
+    println!("cus per domain: {per_domain:?}");
+    let head: Vec<u32> = cu_dom.iter().take(16).copied().collect();
+    println!("cu -> domain (first 16): {head:?}");
+
+    if !(domains as usize >= nodes && (domains as usize).is_multiple_of(nodes)) {
+        println!("PLACED but {domains} domains do not divide over {nodes} nodes: falls back to cu % nodes");
+        return;
+    }
+    let per = domains as usize / nodes;
+    let mut cus_per_node = vec![0usize; nodes];
+    for &d in cu_dom.iter().filter(|&&d| d != u32::MAX) {
+        cus_per_node[d as usize / per] += 1;
+    }
+    println!("PLACED: {domains} domains / {nodes} nodes = {per} per node, cus per node: {cus_per_node:?}");
+
+    // What each node actually has to RUN. Stream entries per cu is the work unit the static
+    // walk executes, and the makespan is set by the busiest node, so this is the number that
+    // decides whether a locality plan costs more than it can buy.
+    println!("\nwork per node (stream entries), busiest node sets the makespan:");
+    for (pi, p) in blob.progs.iter().enumerate() {
+        let (mut placed, mut rr) = (vec![0usize; nodes], vec![0usize; nodes]);
+        for cu in 0..blob.n_cu as usize {
+            let n = p.stream_len[cu] as usize;
+            if cu_dom[cu] != u32::MAX {
+                placed[cu_dom[cu] as usize / per] += n;
+            }
+            rr[cu % nodes] += n;
+        }
+        let ratio =
+            |v: &[usize]| *v.iter().max().unwrap() as f64 / *v.iter().min().unwrap().max(&1) as f64;
+        println!(
+            "  prog[{pi}] T={:<5} placed max/min {:.2}x {placed:?}\n              {:11} round-robin max/min {:.2}x {rr:?}",
+            p.t,
+            ratio(&placed),
+            "",
+            ratio(&rr)
+        );
+    }
+}

--- a/crates/plowrt/src/config.rs
+++ b/crates/plowrt/src/config.rs
@@ -220,6 +220,18 @@ pub struct CpuRuntimeConfig {
     /// with a different type.
     #[arg(long = "cpu-global-queue", env = "PLOW_CPU_GQ", default_value_t = false, value_parser = clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set, require_equals = true, num_args = 0..=1, default_missing_value = "true", global = true)]
     pub gq_opt_in: bool,
+
+    /// Place executors by the packet's L2 locality domains instead of `cu % nodes`.
+    ///
+    /// OFF, because it measured 1.5x SLOWER on the one blob shape testable here (an H100-mapped
+    /// Gemma-4-31B, blocked domain map) and never faster on any node count tried. A domain is a
+    /// GPU L2 partition: it says which slices share a GPU cache, not which weights they touch, and
+    /// CPU model tensors are interleaved across nodes anyway — so grouping by it buys no locality
+    /// while costing the round-robin's balance. Kept for A/B on a host whose blob has balanced
+    /// domains. Inert on a blob carrying none, and `node_plan` declines a plan that would leave
+    /// any node busier than the round-robin even when this is on.
+    #[arg(long = "cpu-l2-place", env = "PLOW_CPU_L2_PLACE", default_value_t = false, value_parser = clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set, require_equals = true, num_args = 0..=1, default_missing_value = "true", global = true)]
+    pub l2_place: bool,
 }
 
 /// NVIDIA / sm_120 runtime knobs.

--- a/crates/plowrt/src/exec/cpu/engine.rs
+++ b/crates/plowrt/src/exec/cpu/engine.rs
@@ -13,7 +13,7 @@ use std::ffi::c_void;
 use std::path::Path;
 use std::time::Instant;
 
-use packet::dev::{DevInst64, DevOp, StreamEnt, TENSOR_NONE16};
+use packet::dev::{DevInst64, DevOp, StreamEnt, SE_DOMAIN_MASK, SE_DOMAIN_SHIFT, TENSOR_NONE16};
 
 use crate::asset::checkpoint::Checkpoint;
 use crate::asset::devblob::{DevBlob, DevProg};
@@ -1109,6 +1109,164 @@ fn dense_row_decode(p: &DevProg) -> bool {
     })
 }
 
+/// cu -> L2 locality domain, plus the domain count, recovered from the bits the emitter tags onto
+/// every stream entry (`SE_DOMAIN_MASK`). `L2Layout::domain_of` is a pure function of the workgroup
+/// index and one layout serves a whole build, so each cu's entries all carry the same value and the
+/// placed programs agree; both are checked rather than assumed.
+///
+/// `None` keeps placement on the topology-only round-robin, which is the right answer whenever the
+/// blob expresses no locality: no `PLOW_L2_PLACE` at compile time, the legacy layout that encoded
+/// the domain in `seg` rather than in flags (every domain bit reads zero), a single domain, or
+/// placed programs that disagree. The domain is a RELATIVE hint about which slices share producers
+/// — never a node id — so the mapping onto real NUMA nodes happens here, at load, where the host
+/// topology is known. That is what keeps one blob portable across hosts with different node counts.
+fn cu_domains(progs: &[DevProg], n_cu: u32) -> Option<(Vec<u32>, u32)> {
+    let mut dom = vec![u32::MAX; n_cu as usize];
+    let mut domains = 0u32;
+    for p in progs.iter().filter(|p| p.l2_domains != 0) {
+        if domains != 0 && domains != p.l2_domains {
+            return None;
+        }
+        // `validate_cpu_blob` has already sized these, but this stays total for any caller.
+        if p.stream_ofs.len() < n_cu as usize || p.stream_len.len() < n_cu as usize {
+            return None;
+        }
+        domains = p.l2_domains;
+        for (cu, slot) in dom.iter_mut().enumerate() {
+            let start = p.stream_ofs[cu] as usize;
+            for e in &p.stream[start..start + p.stream_len[cu] as usize] {
+                let d = ((e.flags & SE_DOMAIN_MASK) >> SE_DOMAIN_SHIFT) as u32;
+                if d >= domains {
+                    return None;
+                }
+                if *slot == u32::MAX {
+                    *slot = d;
+                } else if *slot != d {
+                    return None;
+                }
+            }
+        }
+    }
+    if domains < 2 || dom.iter().all(|&d| d == u32::MAX) {
+        return None;
+    }
+    // A cu no placed program gave work to carries no hint; spread those so they stay balanced.
+    for (cu, d) in dom.iter_mut().enumerate() {
+        if *d == u32::MAX {
+            *d = cu as u32 % domains;
+        }
+    }
+    Some((dom, domains))
+}
+
+/// Node position for every cu, from the packet's locality domains.
+///
+/// Applied only when the domains divide evenly over the nodes: same-domain cus then share a node
+/// AND every node keeps an identical share of the cus. Spreading work over all nodes is the larger,
+/// measured effect (the release report puts distributed placement at 2.3-2.6x node-0-only at 24
+/// workers), so an uneven split is not worth trading for locality — `None` falls back to the
+/// round-robin, which is exactly balanced by construction.
+fn node_plan(cu_dom: &[u32], domains: u32, nodes: usize) -> Option<Vec<u32>> {
+    if nodes < 2 || (domains as usize) < nodes || !(domains as usize).is_multiple_of(nodes) {
+        return None;
+    }
+    let per = domains as usize / nodes;
+    Some(cu_dom.iter().map(|&d| (d as usize / per) as u32).collect())
+}
+
+#[cfg(test)]
+mod placement_tests {
+    use super::*;
+
+    fn prog(n_cu: u32, l2_domains: u32, dom_of: impl Fn(u32) -> u32) -> DevProg {
+        let (mut stream, mut ofs, mut len) = (Vec::new(), Vec::new(), Vec::new());
+        for cu in 0..n_cu {
+            ofs.push(stream.len() as u32);
+            len.push(2);
+            for _ in 0..2 {
+                stream.push(StreamEnt {
+                    flags: (dom_of(cu) as u16) << SE_DOMAIN_SHIFT,
+                    ..Default::default()
+                });
+            }
+        }
+        DevProg {
+            t: 1,
+            packed_prefill_only: false,
+            n_counter: 0,
+            insts: Vec::new(),
+            stream,
+            stream_ofs: ofs,
+            stream_len: len,
+            waits: Vec::new(),
+            succs: Vec::new(),
+            gq_stream: Vec::new(),
+            gq_seg_ofs: Vec::new(),
+            l2_domains,
+        }
+    }
+
+    /// Both hardware maps the emitter can have used: AMD CDNA round-robin and NVIDIA blocked.
+    /// The recovery reads the tagged bits, so it does not need to know which.
+    #[test]
+    fn recovers_either_hardware_domain_map() {
+        for map in [(|cu: u32| cu % 8) as fn(u32) -> u32, |cu: u32| cu / 8] {
+            let (dom, domains) = cu_domains(&[prog(64, 8, map)], 64).expect("placed blob");
+            assert_eq!(domains, 8);
+            assert_eq!(dom, (0..64).map(map).collect::<Vec<_>>());
+        }
+    }
+
+    /// A blob that expresses no locality must leave placement alone. The legacy layout that put
+    /// the domain in `seg` reads as all-zero domain bits, which is the `l2_domains == 0` case.
+    #[test]
+    fn unplaced_or_single_domain_blob_has_no_plan() {
+        assert!(cu_domains(&[prog(64, 0, |cu| cu % 8)], 64).is_none());
+        assert!(cu_domains(&[prog(64, 1, |_| 0)], 64).is_none());
+        assert!(cu_domains(&[], 64).is_none());
+    }
+
+    /// One layout serves a whole build, so placed programs must agree; a blob that disagrees has
+    /// no single map to honour. An unplaced program alongside a placed one is fine -- it expresses
+    /// no locality, so it is indifferent to where its cus land.
+    #[test]
+    fn disagreeing_programs_have_no_plan() {
+        let progs = vec![prog(64, 8, |cu| cu % 8), prog(64, 8, |cu| cu / 8)];
+        assert!(cu_domains(&progs, 64).is_none());
+        let mixed = vec![prog(64, 8, |cu| cu % 8), prog(64, 0, |_| 0)];
+        assert!(cu_domains(&mixed, 64).is_some());
+    }
+
+    #[test]
+    fn domain_beyond_the_declared_count_is_rejected() {
+        assert!(cu_domains(&[prog(64, 4, |cu| cu % 8)], 64).is_none());
+    }
+
+    /// Same-domain cus share a node, and every node keeps an equal share.
+    #[test]
+    fn node_plan_groups_domains_onto_nodes() {
+        let (dom, domains) = cu_domains(&[prog(64, 8, |cu| cu % 8)], 64).unwrap();
+        let plan = node_plan(&dom, domains, 2).expect("8 domains divide over 2 nodes");
+        for cu in 0..64u32 {
+            assert_eq!(plan[cu as usize], dom[cu as usize] / 4);
+        }
+        for node in 0..2u32 {
+            assert_eq!(plan.iter().filter(|&&p| p == node).count(), 32);
+        }
+    }
+
+    /// Spreading over every node is the larger measured effect, so a split that would leave the
+    /// nodes uneven -- or that has fewer domains than nodes -- declines rather than trade it away.
+    #[test]
+    fn node_plan_declines_when_it_cannot_stay_balanced() {
+        let (dom, domains) = cu_domains(&[prog(64, 8, |cu| cu % 8)], 64).unwrap();
+        assert!(node_plan(&dom, domains, 3).is_none(), "8 domains, 3 nodes");
+        assert!(node_plan(&dom, domains, 1).is_none(), "single node");
+        assert!(node_plan(&dom, domains, 16).is_none(), "domains < nodes");
+        assert!(node_plan(&dom, domains, 8).is_some(), "one domain per node");
+    }
+}
+
 fn loaded(
     p: &DevProg,
     n_cu: u32,
@@ -1372,7 +1530,33 @@ impl CpuEngine {
         let exec = Arc::new(KernelExec::new(&model, threads, |w| {
             placement[w % placement.len()].1
         })?);
-        let pool = WorkerPool::spawn(&topo, threads, &opts.numa, opts.spin_us, n_cu, exec);
+        // The packet's locality hint, mapped onto this host's nodes. Absent for an unplaced blob,
+        // one node, or domains that do not divide over the nodes: placement stays cu % nodes.
+        let cu_dom = cu_domains(&model.blob.progs, n_cu);
+        let plan = cu_dom
+            .as_ref()
+            .and_then(|(d, n)| node_plan(d, *n, nodes.len()).map(|p| (p, *n)));
+        match &plan {
+            Some((_, domains)) => tracing::info!(
+                domains,
+                nodes = nodes.len(),
+                "CPU NUMA placement follows the packet's L2 locality domains"
+            ),
+            None => tracing::debug!(
+                nodes = nodes.len(),
+                l2_domains = cu_dom.as_ref().map(|(_, n)| *n).unwrap_or(0),
+                "CPU NUMA placement is round-robin; no usable packet locality plan"
+            ),
+        }
+        let pool = WorkerPool::spawn(
+            &topo,
+            threads,
+            &opts.numa,
+            opts.spin_us,
+            n_cu,
+            plan.as_ref().map(|(p, n)| (p.as_slice(), *n)),
+            exec,
+        );
         let progs: Vec<Arc<LoadedProgram>> = model
             .blob
             .progs

--- a/crates/plowrt/src/exec/cpu/engine.rs
+++ b/crates/plowrt/src/exec/cpu/engine.rs
@@ -1164,6 +1164,38 @@ pub fn cu_domains(progs: &[DevProg], n_cu: u32) -> Option<(Vec<u32>, u32)> {
     Some((dom, domains))
 }
 
+/// Workers to spawn: the width the topology and model want, but never more than the packet has
+/// executors.
+///
+/// `cu_map` deals cus `0..n_cu` over the pool, so a worker past `n_cu` owns nothing in EVERY
+/// program. It cannot be rescued by any later narrowing: it wakes on each run, finds an empty
+/// stream, returns to the control ring, and spins `--cpu-spin-us` before parking — on the cores the
+/// working set needs. This is NOT the per-program narrowing that measured worse (see the note at
+/// the call site); those workers were idle for one program and busy for another, while these are
+/// unusable for the whole model, so there is no width tradeoff to lose.
+///
+/// Measured on Gemma-4-31B dense, `n_cu = 144`, 8-node EPYC 9654, means of 3 (TTFT / decode step):
+///
+/// | workers | TTFT | decode step |
+/// |---|---|---|
+/// | 384 (all logical, the old default) | 20.50 s | 3459 ms |
+/// | 192 (all physical) | 16.24 s | 1196 ms |
+/// | 144 (`n_cu`) | 14.08 s | 415 ms |
+///
+/// The decode penalty tracks the idle count — 240 idle is 8.3x, 48 idle is 2.9x, 0 is baseline.
+///
+/// The global queue is exempt: there every worker claims from the shared window, so workers past
+/// `n_cu` do useful work rather than idling. An explicit `--cpu-threads` is always honoured.
+fn worker_width(explicit: usize, want: usize, n_cu: u32, gq: bool) -> usize {
+    if explicit != 0 {
+        return explicit;
+    }
+    if gq {
+        return want.max(1);
+    }
+    want.min(n_cu as usize).max(1)
+}
+
 /// Stream entries each cu runs, ONE VECTOR PER PROGRAM — the work unit the static walk executes.
 ///
 /// Kept per program rather than summed because programs are ALTERNATIVES: a prefill bucket or the
@@ -1428,6 +1460,30 @@ mod placement_tests {
         assert!(cu_domains(&[q], 8).is_none());
     }
 
+    /// A worker past `n_cu` owns nothing in any program and only costs its spin, so the auto width
+    /// is capped. Measured 8.3x on decode; the explicit override and the global queue are exempt.
+    #[test]
+    fn worker_width_never_exceeds_the_packet() {
+        assert_eq!(worker_width(0, 384, 144, false), 144, "capped at n_cu");
+        assert_eq!(
+            worker_width(0, 96, 144, false),
+            96,
+            "no cap needed below n_cu"
+        );
+        assert_eq!(
+            worker_width(0, 384, 144, true),
+            384,
+            "global queue uses every worker"
+        );
+        assert_eq!(
+            worker_width(192, 384, 144, false),
+            192,
+            "explicit --cpu-threads wins"
+        );
+        assert_eq!(worker_width(512, 384, 144, false), 512, "even above n_cu");
+        assert_eq!(worker_width(0, 8, 0, false), 1, "never zero workers");
+    }
+
     /// `cu_work` keeps one row per program rather than collapsing them.
     #[test]
     fn cu_work_is_per_program() {
@@ -1690,7 +1746,12 @@ impl CpuEngine {
         // pool whose prefill was narrowed to 8. Fixing that needs the idle worker to stop polling,
         // which is the real prerequisite for per-phase widths.
         let wants_logical = model.blob.progs.iter().any(dense_row_decode);
-        let threads = threads.max(if wants_logical { logical_w } else { physical_w });
+        let threads = worker_width(
+            opts.threads,
+            threads.max(if wants_logical { logical_w } else { physical_w }),
+            n_cu,
+            crate::config::RuntimeConfig::get().cpu.gq_opt_in,
+        );
         tracing::info!(
             threads,
             ?isa,

--- a/crates/plowrt/src/exec/cpu/engine.rs
+++ b/crates/plowrt/src/exec/cpu/engine.rs
@@ -1159,19 +1159,39 @@ fn cu_domains(progs: &[DevProg], n_cu: u32) -> Option<(Vec<u32>, u32)> {
     Some((dom, domains))
 }
 
+/// Stream entries each cu runs, summed over the programs — the work unit the static walk executes.
+fn cu_work(progs: &[DevProg], n_cu: u32) -> Vec<u64> {
+    let mut w = vec![0u64; n_cu as usize];
+    for p in progs {
+        for (cu, slot) in w.iter_mut().enumerate() {
+            *slot += *p.stream_len.get(cu).unwrap_or(&0) as u64;
+        }
+    }
+    w
+}
+
 /// Node position for every cu, from the packet's locality domains.
 ///
-/// Applied only when the domains divide evenly over the nodes: same-domain cus then share a node
-/// AND every node keeps an identical share of the cus. Spreading work over all nodes is the larger,
-/// measured effect (the release report puts distributed placement at 2.3-2.6x node-0-only at 24
-/// workers), so an uneven split is not worth trading for locality — `None` falls back to the
-/// round-robin, which is exactly balanced by construction.
-fn node_plan(cu_dom: &[u32], domains: u32, nodes: usize) -> Option<Vec<u32>> {
+/// Requires the domains to divide over the nodes AND the resulting split to leave no node busier
+/// than the round-robin would. That second test is the one that matters, and it is measured, not
+/// assumed: a domain is a GPU L2 partition, and nothing makes its slices equal in COST. The blocked
+/// map (`cu / sms_per_partition`) is the worst case — low-numbered cus carry every op that is
+/// sliced narrowly, so grouping them puts a third of the packet on one node. On a real H100-mapped
+/// Gemma-4 blob that is a 3.0-4.1x work spread across nodes against round-robin's 1.04-1.12x, and
+/// it measured 1.5x slower end to end. The makespan is set by the busiest node, so comparing peaks
+/// is the right test; `None` falls back to the round-robin.
+fn node_plan(cu_dom: &[u32], domains: u32, nodes: usize, work: &[u64]) -> Option<Vec<u32>> {
     if nodes < 2 || (domains as usize) < nodes || !(domains as usize).is_multiple_of(nodes) {
         return None;
     }
     let per = domains as usize / nodes;
-    Some(cu_dom.iter().map(|&d| (d as usize / per) as u32).collect())
+    let plan: Vec<u32> = cu_dom.iter().map(|&d| (d as usize / per) as u32).collect();
+    let (mut placed, mut rr) = (vec![0u64; nodes], vec![0u64; nodes]);
+    for (cu, &w) in work.iter().enumerate().take(plan.len()) {
+        placed[plan[cu] as usize] += w;
+        rr[cu % nodes] += w;
+    }
+    (placed.iter().max() <= rr.iter().max()).then_some(plan)
 }
 
 #[cfg(test)]
@@ -1246,7 +1266,8 @@ mod placement_tests {
     #[test]
     fn node_plan_groups_domains_onto_nodes() {
         let (dom, domains) = cu_domains(&[prog(64, 8, |cu| cu % 8)], 64).unwrap();
-        let plan = node_plan(&dom, domains, 2).expect("8 domains divide over 2 nodes");
+        let flat = vec![1u64; 64];
+        let plan = node_plan(&dom, domains, 2, &flat).expect("8 domains divide over 2 nodes");
         for cu in 0..64u32 {
             assert_eq!(plan[cu as usize], dom[cu as usize] / 4);
         }
@@ -1255,15 +1276,67 @@ mod placement_tests {
         }
     }
 
-    /// Spreading over every node is the larger measured effect, so a split that would leave the
-    /// nodes uneven -- or that has fewer domains than nodes -- declines rather than trade it away.
+    /// The AMD round-robin map is `cu % domains`, so at `domains == nodes` the plan reduces to
+    /// `cu % nodes` — exactly the placement it replaces. A real gfx950 blob lands here on an
+    /// 8-node host, which is why an A/B of the two placements only says anything at other node
+    /// counts; the plan diverges as soon as the counts differ.
+    #[test]
+    fn an_amd_map_matching_the_node_count_reproduces_the_round_robin() {
+        let (dom, domains) = cu_domains(&[prog(304, 8, |cu| cu % 8)], 304).unwrap();
+        let flat = vec![1u64; 304];
+        let same = node_plan(&dom, domains, 8, &flat).unwrap();
+        assert!(
+            (0..304).all(|cu| same[cu] == cu as u32 % 8),
+            "identical at 8 nodes"
+        );
+        let differs = node_plan(&dom, domains, 2, &flat).unwrap();
+        assert!(
+            (0..304).any(|cu| differs[cu] != cu as u32 % 2),
+            "and diverges at 2 nodes, where the A/B is meaningful"
+        );
+    }
+
+    /// Spreading over every node is the larger measured effect, so a split with fewer domains than
+    /// nodes, or one that does not divide, declines rather than trade it away.
     #[test]
     fn node_plan_declines_when_it_cannot_stay_balanced() {
         let (dom, domains) = cu_domains(&[prog(64, 8, |cu| cu % 8)], 64).unwrap();
-        assert!(node_plan(&dom, domains, 3).is_none(), "8 domains, 3 nodes");
-        assert!(node_plan(&dom, domains, 1).is_none(), "single node");
-        assert!(node_plan(&dom, domains, 16).is_none(), "domains < nodes");
-        assert!(node_plan(&dom, domains, 8).is_some(), "one domain per node");
+        let flat = vec![1u64; 64];
+        assert!(
+            node_plan(&dom, domains, 3, &flat).is_none(),
+            "8 domains, 3 nodes"
+        );
+        assert!(node_plan(&dom, domains, 1, &flat).is_none(), "single node");
+        assert!(
+            node_plan(&dom, domains, 16, &flat).is_none(),
+            "domains < nodes"
+        );
+        assert!(
+            node_plan(&dom, domains, 8, &flat).is_some(),
+            "one domain per node"
+        );
+    }
+
+    /// The measured failure, reproduced: the blocked map puts every narrowly-sliced op's cus on
+    /// one node. Equal cu COUNTS per node say nothing about equal cost, so the guard compares the
+    /// busiest node's work against what the round-robin would give it. This shape ran 1.5x slower
+    /// end to end on the real blob, and must be declined.
+    #[test]
+    fn node_plan_declines_a_plan_that_makes_the_busiest_node_worse() {
+        // 132 cus, blocked over 8 domains of 18: domain 7 gets 6 cus, and low cus carry more work.
+        let (dom, domains) = cu_domains(&[prog(132, 8, |cu| (cu / 18).min(7))], 132).unwrap();
+        let skewed: Vec<u64> = (0..132).map(|cu| 132 - cu as u64).collect();
+        assert!(
+            node_plan(&dom, domains, 8, &skewed).is_none(),
+            "declines the skew"
+        );
+        // The same domains with flat per-cu cost still balance, so the guard is not blanket-off.
+        let flat = vec![1u64; 132];
+        let n = node_plan(&dom, domains, 8, &flat);
+        assert!(
+            n.is_none(),
+            "18/18/../6 cus per node is already worse than round-robin"
+        );
     }
 }
 
@@ -1532,10 +1605,15 @@ impl CpuEngine {
         })?);
         // The packet's locality hint, mapped onto this host's nodes. Absent for an unplaced blob,
         // one node, or domains that do not divide over the nodes: placement stays cu % nodes.
-        let cu_dom = cu_domains(&model.blob.progs, n_cu);
-        let plan = cu_dom
-            .as_ref()
-            .and_then(|(d, n)| node_plan(d, *n, nodes.len()).map(|p| (p, *n)));
+        let cu_dom = crate::config::RuntimeConfig::get()
+            .cpu
+            .l2_place
+            .then(|| cu_domains(&model.blob.progs, n_cu))
+            .flatten();
+        let plan = cu_dom.as_ref().and_then(|(d, n)| {
+            let work = cu_work(&model.blob.progs, n_cu);
+            node_plan(d, *n, nodes.len(), &work).map(|p| (p, *n))
+        });
         match &plan {
             Some((_, domains)) => tracing::info!(
                 domains,

--- a/crates/plowrt/src/exec/cpu/engine.rs
+++ b/crates/plowrt/src/exec/cpu/engine.rs
@@ -1134,7 +1134,12 @@ pub fn cu_domains(progs: &[DevProg], n_cu: u32) -> Option<(Vec<u32>, u32)> {
         domains = p.l2_domains;
         for (cu, slot) in dom.iter_mut().enumerate() {
             let start = p.stream_ofs[cu] as usize;
-            for e in &p.stream[start..start + p.stream_len[cu] as usize] {
+            // Slicing directly would panic on a blob that never went through `validate_cpu_blob`,
+            // which a caller outside the engine (the l2_probe example) does not run.
+            let entries = start
+                .checked_add(p.stream_len[cu] as usize)
+                .and_then(|end| p.stream.get(start..end))?;
+            for e in entries {
                 let d = ((e.flags & SE_DOMAIN_MASK) >> SE_DOMAIN_SHIFT) as u32;
                 if d >= domains {
                     return None;
@@ -1207,6 +1212,11 @@ pub fn node_plan(
     work: &[Vec<u64>],
 ) -> Option<Vec<u32>> {
     if nodes < 2 || (domains as usize) < nodes || !(domains as usize).is_multiple_of(nodes) {
+        return None;
+    }
+    // No work to judge means nothing establishes the plan is safe; `all()` on an empty slice is
+    // vacuously true, which would turn "unknown" into "approved".
+    if work.is_empty() {
         return None;
     }
     let per = domains as usize / nodes;
@@ -1396,6 +1406,26 @@ mod placement_tests {
         // Sanity that this shape is otherwise acceptable, so the rejection is the imbalance.
         let flat = vec![vec![1u64; 4]];
         assert!(node_plan(&dom, domains, 2, &flat).is_some());
+    }
+
+    /// No work rows means nothing established the plan is safe. `all()` over an empty slice is
+    /// vacuously true, so this has to be rejected explicitly or "unknown" reads as "approved".
+    #[test]
+    fn node_plan_declines_with_no_work_to_judge() {
+        let (dom, domains) = cu_domains(&[prog(64, 8, |cu| cu % 8)], 64).unwrap();
+        assert!(node_plan(&dom, domains, 8, &[]).is_none());
+    }
+
+    /// `cu_domains` is `pub` and the probe calls it on a blob that never saw `validate_cpu_blob`,
+    /// so a stream window past the end has to decline rather than panic.
+    #[test]
+    fn cu_domains_declines_a_stream_window_past_the_end() {
+        let mut p = prog(8, 2, |cu| cu / 4);
+        p.stream_len[3] = 9_999;
+        assert!(cu_domains(&[p], 8).is_none());
+        let mut q = prog(8, 2, |cu| cu / 4);
+        q.stream_ofs[5] = u32::MAX;
+        assert!(cu_domains(&[q], 8).is_none());
     }
 
     /// `cu_work` keeps one row per program rather than collapsing them.

--- a/crates/plowrt/src/exec/cpu/engine.rs
+++ b/crates/plowrt/src/exec/cpu/engine.rs
@@ -1120,7 +1120,7 @@ fn dense_row_decode(p: &DevProg) -> bool {
 /// placed programs that disagree. The domain is a RELATIVE hint about which slices share producers
 /// — never a node id — so the mapping onto real NUMA nodes happens here, at load, where the host
 /// topology is known. That is what keeps one blob portable across hosts with different node counts.
-fn cu_domains(progs: &[DevProg], n_cu: u32) -> Option<(Vec<u32>, u32)> {
+pub fn cu_domains(progs: &[DevProg], n_cu: u32) -> Option<(Vec<u32>, u32)> {
     let mut dom = vec![u32::MAX; n_cu as usize];
     let mut domains = 0u32;
     for p in progs.iter().filter(|p| p.l2_domains != 0) {
@@ -1159,39 +1159,64 @@ fn cu_domains(progs: &[DevProg], n_cu: u32) -> Option<(Vec<u32>, u32)> {
     Some((dom, domains))
 }
 
-/// Stream entries each cu runs, summed over the programs — the work unit the static walk executes.
-fn cu_work(progs: &[DevProg], n_cu: u32) -> Vec<u64> {
-    let mut w = vec![0u64; n_cu as usize];
-    for p in progs {
-        for (cu, slot) in w.iter_mut().enumerate() {
-            *slot += *p.stream_len.get(cu).unwrap_or(&0) as u64;
-        }
+/// Stream entries each cu runs, ONE VECTOR PER PROGRAM — the work unit the static walk executes.
+///
+/// Kept per program rather than summed because programs are ALTERNATIVES: a prefill bucket or the
+/// decode program is chosen per dispatch, and their loads never overlap. Summing them lets a plan
+/// that ruins one program hide behind another that leans the other way — two programs at 200/2 and
+/// 2/200 across a pair of nodes total 202/202 and look perfectly balanced, while each one on its
+/// own is a 100x spread.
+pub fn cu_work(progs: &[DevProg], n_cu: u32) -> Vec<Vec<u64>> {
+    progs
+        .iter()
+        .map(|p| {
+            (0..n_cu as usize)
+                .map(|cu| *p.stream_len.get(cu).unwrap_or(&0) as u64)
+                .collect()
+        })
+        .collect()
+}
+
+/// Busiest node under `plan` and under the `cu % nodes` round-robin, for one program's work.
+fn peak_loads(plan: &[u32], work: &[u64], nodes: usize) -> (u64, u64) {
+    let (mut placed, mut rr) = (vec![0u64; nodes], vec![0u64; nodes]);
+    for (cu, &w) in work.iter().enumerate().take(plan.len()) {
+        placed[plan[cu] as usize % nodes] += w;
+        rr[cu % nodes] += w;
     }
-    w
+    (
+        placed.into_iter().max().unwrap_or(0),
+        rr.into_iter().max().unwrap_or(0),
+    )
 }
 
 /// Node position for every cu, from the packet's locality domains.
 ///
 /// Requires the domains to divide over the nodes AND the resulting split to leave no node busier
-/// than the round-robin would. That second test is the one that matters, and it is measured, not
-/// assumed: a domain is a GPU L2 partition, and nothing makes its slices equal in COST. The blocked
-/// map (`cu / sms_per_partition`) is the worst case — low-numbered cus carry every op that is
-/// sliced narrowly, so grouping them puts a third of the packet on one node. On a real H100-mapped
-/// Gemma-4 blob that is a 3.0-4.1x work spread across nodes against round-robin's 1.04-1.12x, and
-/// it measured 1.5x slower end to end. The makespan is set by the busiest node, so comparing peaks
-/// is the right test; `None` falls back to the round-robin.
-fn node_plan(cu_dom: &[u32], domains: u32, nodes: usize, work: &[u64]) -> Option<Vec<u32>> {
+/// than the round-robin would, in EVERY program. That second test is the one that matters, and it
+/// is measured, not assumed: a domain is a GPU L2 partition, and nothing makes its slices equal in
+/// COST. The blocked map (`cu / sms_per_partition`) is the worst case — low-numbered cus carry every
+/// op that is sliced narrowly, so grouping them puts a third of the packet on one node. On a real
+/// H100-mapped Gemma-4 blob that is a 3.0-4.1x work spread across nodes against round-robin's
+/// 1.04-1.12x, and it measured 1.5x slower end to end. The makespan is set by the busiest node, so
+/// comparing peaks is the right test; `None` falls back to the round-robin.
+pub fn node_plan(
+    cu_dom: &[u32],
+    domains: u32,
+    nodes: usize,
+    work: &[Vec<u64>],
+) -> Option<Vec<u32>> {
     if nodes < 2 || (domains as usize) < nodes || !(domains as usize).is_multiple_of(nodes) {
         return None;
     }
     let per = domains as usize / nodes;
     let plan: Vec<u32> = cu_dom.iter().map(|&d| (d as usize / per) as u32).collect();
-    let (mut placed, mut rr) = (vec![0u64; nodes], vec![0u64; nodes]);
-    for (cu, &w) in work.iter().enumerate().take(plan.len()) {
-        placed[plan[cu] as usize] += w;
-        rr[cu % nodes] += w;
-    }
-    (placed.iter().max() <= rr.iter().max()).then_some(plan)
+    work.iter()
+        .all(|w| {
+            let (placed, rr) = peak_loads(&plan, w, nodes);
+            placed <= rr
+        })
+        .then_some(plan)
 }
 
 #[cfg(test)]
@@ -1266,7 +1291,7 @@ mod placement_tests {
     #[test]
     fn node_plan_groups_domains_onto_nodes() {
         let (dom, domains) = cu_domains(&[prog(64, 8, |cu| cu % 8)], 64).unwrap();
-        let flat = vec![1u64; 64];
+        let flat = vec![vec![1u64; 64]];
         let plan = node_plan(&dom, domains, 2, &flat).expect("8 domains divide over 2 nodes");
         for cu in 0..64u32 {
             assert_eq!(plan[cu as usize], dom[cu as usize] / 4);
@@ -1283,7 +1308,7 @@ mod placement_tests {
     #[test]
     fn an_amd_map_matching_the_node_count_reproduces_the_round_robin() {
         let (dom, domains) = cu_domains(&[prog(304, 8, |cu| cu % 8)], 304).unwrap();
-        let flat = vec![1u64; 304];
+        let flat = vec![vec![1u64; 304]];
         let same = node_plan(&dom, domains, 8, &flat).unwrap();
         assert!(
             (0..304).all(|cu| same[cu] == cu as u32 % 8),
@@ -1301,7 +1326,7 @@ mod placement_tests {
     #[test]
     fn node_plan_declines_when_it_cannot_stay_balanced() {
         let (dom, domains) = cu_domains(&[prog(64, 8, |cu| cu % 8)], 64).unwrap();
-        let flat = vec![1u64; 64];
+        let flat = vec![vec![1u64; 64]];
         assert!(
             node_plan(&dom, domains, 3, &flat).is_none(),
             "8 domains, 3 nodes"
@@ -1325,18 +1350,61 @@ mod placement_tests {
     fn node_plan_declines_a_plan_that_makes_the_busiest_node_worse() {
         // 132 cus, blocked over 8 domains of 18: domain 7 gets 6 cus, and low cus carry more work.
         let (dom, domains) = cu_domains(&[prog(132, 8, |cu| (cu / 18).min(7))], 132).unwrap();
-        let skewed: Vec<u64> = (0..132).map(|cu| 132 - cu as u64).collect();
+        let skewed = vec![(0..132).map(|cu| 132 - cu as u64).collect::<Vec<u64>>()];
         assert!(
             node_plan(&dom, domains, 8, &skewed).is_none(),
             "declines the skew"
         );
         // The same domains with flat per-cu cost still balance, so the guard is not blanket-off.
-        let flat = vec![1u64; 132];
+        let flat = vec![vec![1u64; 132]];
         let n = node_plan(&dom, domains, 8, &flat);
         assert!(
             n.is_none(),
             "18/18/../6 cus per node is already worse than round-robin"
         );
+    }
+
+    /// Programs are ALTERNATIVES, so the balance test has to hold for each separately. Two that
+    /// lean opposite ways sum to a perfectly balanced total while each on its own is ruinous —
+    /// summing first would approve exactly the placement the guard exists to reject.
+    #[test]
+    fn a_program_cannot_hide_its_imbalance_behind_another() {
+        // 4 cus, 2 domains, 2 nodes: cus 0,1 -> node 0 and cus 2,3 -> node 1 under the plan,
+        // against round-robin's 0,2 -> node 0 and 1,3 -> node 1.
+        let (dom, domains) = cu_domains(&[prog(4, 2, |cu| cu / 2)], 4).unwrap();
+        let a = vec![100u64, 100, 1, 1]; // plan 200/2, round-robin 101/101
+        let b = vec![1u64, 1, 100, 100]; // plan 2/200, round-robin 101/101
+        for one in [&a, &b] {
+            assert!(
+                node_plan(&dom, domains, 2, std::slice::from_ref(one)).is_none(),
+                "each program alone is a 200-vs-2 split and must be declined"
+            );
+        }
+        assert!(
+            node_plan(&dom, domains, 2, &[a.clone(), b.clone()]).is_none(),
+            "and together too: their sum balances, but neither program ever runs as the sum"
+        );
+        // The hole this closes, made explicit: summing first yields a flat 101 per cu, which the
+        // peak test then waves through. That was the earlier `cu_work`, and it is why the work is
+        // now carried one row per program.
+        let summed: Vec<u64> = (0..4).map(|i| a[i] + b[i]).collect();
+        assert!(summed.iter().all(|&x| x == 101));
+        assert!(
+            node_plan(&dom, domains, 2, &[summed]).is_some(),
+            "the summed view approves the very placement each program rejects"
+        );
+        // Sanity that this shape is otherwise acceptable, so the rejection is the imbalance.
+        let flat = vec![vec![1u64; 4]];
+        assert!(node_plan(&dom, domains, 2, &flat).is_some());
+    }
+
+    /// `cu_work` keeps one row per program rather than collapsing them.
+    #[test]
+    fn cu_work_is_per_program() {
+        let progs = vec![prog(4, 2, |cu| cu / 2), prog(4, 2, |cu| cu / 2)];
+        let w = cu_work(&progs, 4);
+        assert_eq!(w.len(), 2, "one row per program, not one summed row");
+        assert!(w.iter().all(|r| r.len() == 4 && r.iter().all(|&x| x == 2)));
     }
 }
 

--- a/crates/plowrt/src/exec/cpu/workers.rs
+++ b/crates/plowrt/src/exec/cpu/workers.rs
@@ -39,10 +39,20 @@ struct Shared {
     n_workers: u32,
 }
 
-/// cu -> worker ownership: node = `cu % nodes`, then round-robin within the node, restricted to the
-/// first `active` workers. Used both at spawn (for the pool's own bookkeeping) and per program, so
-/// prefill and decode can run on different widths without respawning threads.
-pub fn cu_map(n_cu: u32, per_node: &[Vec<u32>], nodes: usize, active: usize) -> Vec<Vec<u32>> {
+/// cu -> worker ownership, then round-robin within the node, restricted to the first `active`
+/// workers. Used both at spawn (for the pool's own bookkeeping) and per program, so prefill and
+/// decode can run on different widths without respawning threads.
+///
+/// `node_of_cu` is the packet's locality plan (`engine::node_plan`) when the blob carries L2
+/// domains and they divide over the nodes; without it the node is `cu % nodes`, which spreads
+/// evenly but is blind to which slices actually feed each other.
+pub fn cu_map(
+    n_cu: u32,
+    per_node: &[Vec<u32>],
+    nodes: usize,
+    active: usize,
+    node_of_cu: Option<&[u32]>,
+) -> Vec<Vec<u32>> {
     let mut out: Vec<Vec<u32>> =
         vec![Vec::new(); per_node.iter().map(Vec::len).sum::<usize>().max(active)];
     let live: Vec<Vec<u32>> = per_node
@@ -54,8 +64,14 @@ pub fn cu_map(n_cu: u32, per_node: &[Vec<u32>], nodes: usize, active: usize) -> 
                 .collect()
         })
         .collect();
+    // Per-node round-robin cursor. Under the fallback `cu % nodes` the k-th cu on a node is
+    // `k * nodes + np`, so this counts exactly what `cu / nodes` used to.
+    let mut seen = vec![0usize; nodes.max(1)];
     for cu in 0..n_cu {
-        let np = (cu as usize) % nodes.max(1);
+        let np = match node_of_cu {
+            Some(m) => m[cu as usize] as usize % nodes.max(1),
+            None => (cu as usize) % nodes.max(1),
+        };
         let ws = if live.get(np).is_some_and(|v| !v.is_empty()) {
             &live[np]
         } else {
@@ -64,7 +80,8 @@ pub fn cu_map(n_cu: u32, per_node: &[Vec<u32>], nodes: usize, active: usize) -> 
                 None => return out, // no active worker at all; caller rejects
             }
         };
-        let w = ws[(cu as usize / nodes.max(1)) % ws.len()];
+        let w = ws[seen[np] % ws.len()];
+        seen[np] += 1;
         out[w as usize].push(cu);
     }
     out
@@ -76,6 +93,9 @@ struct WorkerInit {
     node: u32,
     node_pos: u32,
     cpu: u32,
+    /// GQ window this worker claims from first. The packet's locality domain when the blob carries
+    /// one and it maps onto the nodes, else the node position, as before.
+    domain: u32,
 }
 
 /// Keeps the program and counters of the in-flight run alive for the workers,
@@ -105,15 +125,20 @@ struct Host {
 
 impl WorkerPool {
     /// Spawn `threads` persistent workers (0 = one per online logical cpu on the
-    /// selected nodes). Virtual executor `cu` is placed on node `cu % nodes`,
-    /// round-robin across that node's workers, so `n_cu` need not equal the
-    /// thread count.
+    /// selected nodes). Virtual executor `cu` is placed on the node `place` names for it, or on
+    /// `cu % nodes` without one, round-robin across that node's workers — so `n_cu` need not equal
+    /// the thread count, and one blob serves any core count.
+    ///
+    /// `place` is the packet's locality plan: `(node_of_cu, domains)` from `engine::node_plan`.
+    /// It moves same-domain cus onto one node and points each worker's first GQ claim at a domain
+    /// that node owns, instead of at its bare node index.
     pub fn spawn(
         topo: &Topology,
         threads: usize,
         numa: &NumaMode,
         spin_us: u32,
         n_cu: u32,
+        place: Option<(&[u32], u32)>,
         exec: Arc<dyn Exec>,
     ) -> WorkerPool {
         let nodes = topo.select_nodes(numa);
@@ -130,12 +155,29 @@ impl WorkerPool {
         let placement: Vec<(u32, u32)> = (0..threads).map(|k| cpus[k % cpus.len()]).collect();
         let node_pos = |n: u32| nodes.iter().position(|&x| x == n).unwrap_or(0) as u32;
 
-        // cu → worker: node = cu % nodes, then round-robin within the node.
+        // cu → worker: the locality plan's node (else cu % nodes), then round-robin within it.
         let mut per_node: Vec<Vec<u32>> = vec![Vec::new(); nodes.len()];
         for (w, &(_, n)) in placement.iter().enumerate() {
             per_node[node_pos(n) as usize].push(w as u32);
         }
-        let mut cus_of = cu_map(n_cu, &per_node, nodes.len(), threads);
+        let mut cus_of = cu_map(n_cu, &per_node, nodes.len(), threads, place.map(|(m, _)| m));
+
+        // Each node owns a contiguous run of `per` domains under `node_plan`; spread that node's
+        // workers over them, so no window is left to be reached only by stealing. `spawn` resolves
+        // the node list itself, so re-derive the split here instead of trusting the caller's.
+        let per = place
+            .map(|(_, domains)| domains as usize)
+            .filter(|d| *d >= nodes.len() && d.is_multiple_of(nodes.len()))
+            .map(|d| d / nodes.len());
+        let mut worker_domain = vec![0u32; threads];
+        for (p, ws) in per_node.iter().enumerate() {
+            for (k, &w) in ws.iter().enumerate() {
+                worker_domain[w as usize] = match per {
+                    Some(per) => (p * per + k % per) as u32,
+                    None => p as u32,
+                };
+            }
+        }
 
         let shared = Arc::new(Shared {
             ring: ControlRing::new(threads),
@@ -157,6 +199,7 @@ impl WorkerPool {
                 idx: w as u32,
                 node,
                 node_pos: node_pos(node),
+                domain: worker_domain[w],
                 cpu,
             };
             let sh = shared.clone();
@@ -422,7 +465,7 @@ fn worker_main(init: WorkerInit, sh: Arc<Shared>, exec: Arc<dyn Exec>) {
         worker: init.idx,
         node: init.node,
         cpu: init.cpu,
-        domain: init.node_pos,
+        domain: init.domain,
     };
     let mut st = StaticState::new(init.idx as usize, init.cus);
     let mut gq = GqState::new();
@@ -493,5 +536,65 @@ fn worker_main(init: WorkerInit, sh: Arc<Shared>, exec: Arc<dyn Exec>) {
             CMD_STOP => return,
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod placement_tests {
+    use super::cu_map;
+
+    /// Workers laid out over `nodes`, node-major, as `spawn` builds `per_node`.
+    fn per_node(nodes: usize, per: usize) -> Vec<Vec<u32>> {
+        (0..nodes)
+            .map(|n| ((n * per) as u32..((n + 1) * per) as u32).collect())
+            .collect()
+    }
+
+    /// Without a plan the node is `cu % nodes` and the worker within it is `cu / nodes` — the
+    /// mapping this pool has always used. Pinned so the locality plan stays purely additive.
+    #[test]
+    fn without_a_plan_placement_is_the_old_round_robin() {
+        let pn = per_node(2, 3);
+        let got = cu_map(24, &pn, 2, 6, None);
+        for (w, cus) in got.iter().enumerate() {
+            for &cu in cus {
+                assert_eq!(cu as usize % 2, w / 3, "cu {cu} on the wrong node");
+                assert_eq!((cu as usize / 2) % 3, w % 3, "cu {cu} on the wrong worker");
+            }
+        }
+        assert_eq!(got.iter().map(Vec::len).sum::<usize>(), 24);
+        assert!(got.iter().all(|c| c.len() == 4), "even by construction");
+    }
+
+    /// With a plan every cu of one domain lands on that domain's node, and the nodes still split
+    /// the work evenly — locality must not cost balance.
+    #[test]
+    fn a_plan_groups_domains_without_costing_balance() {
+        let pn = per_node(2, 3);
+        let plan: Vec<u32> = (0..24u32).map(|cu| (cu % 8) / 4).collect();
+        let got = cu_map(24, &pn, 2, 6, Some(&plan));
+        for (w, cus) in got.iter().enumerate() {
+            for &cu in cus {
+                assert_eq!(plan[cu as usize] as usize, w / 3, "cu {cu} left its node");
+            }
+        }
+        assert_eq!(got.iter().map(Vec::len).sum::<usize>(), 24);
+        assert!(
+            got.iter().all(|c| c.len() == 4),
+            "3 workers x 12 cus per node"
+        );
+    }
+
+    /// A node with no live worker still has its cus placed somewhere rather than dropped.
+    #[test]
+    fn a_plan_survives_a_node_with_no_active_worker() {
+        let pn = per_node(2, 3);
+        let plan: Vec<u32> = (0..12u32).map(|cu| cu % 2).collect();
+        let got = cu_map(12, &pn, 2, 3, Some(&plan));
+        assert_eq!(got.iter().map(Vec::len).sum::<usize>(), 12);
+        assert!(
+            got[3..].iter().all(Vec::is_empty),
+            "workers past `active` own nothing"
+        );
     }
 }

--- a/crates/plowrt/tests/cpu_interp.rs
+++ b/crates/plowrt/tests/cpu_interp.rs
@@ -23,7 +23,12 @@ struct Op {
 /// (threshold = its block count); slices are dealt round-robin over `n_cu`.
 /// `gq_domains > 0` also emits an op-major global-queue stream split across
 /// that many domain windows per segment.
-fn build(ops: &[Op], n_cu: u32, n_seg: u32, gq_domains: u32) -> (LoadedProgram, Vec<packet::Counter>) {
+fn build(
+    ops: &[Op],
+    n_cu: u32,
+    n_seg: u32,
+    gq_domains: u32,
+) -> (LoadedProgram, Vec<packet::Counter>) {
     let mut insts = Vec::new();
     let mut waits = Vec::new();
     let mut succs = Vec::new();
@@ -193,20 +198,39 @@ fn pool(threads: usize, n_cu: u32, exec: Arc<dyn Exec>) -> WorkerPool {
     WorkerPool::spawn(&topo, threads, &NumaMode::Off, 20, n_cu, None, exec)
 }
 
-fn run_once(p: &WorkerPool, prog: &Arc<LoadedProgram>, pool: &Arc<CounterPool>, seg: u32, rec: &Recorder) {
+fn run_once(
+    p: &WorkerPool,
+    prog: &Arc<LoadedProgram>,
+    pool: &Arc<CounterPool>,
+    seg: u32,
+    rec: &Recorder,
+) {
     pool.reset_all();
-    rec.base.store(prog.insts.as_ptr() as usize, Ordering::Release);
+    rec.base
+        .store(prog.insts.as_ptr() as usize, Ordering::Release);
     let gen = p.run(prog, seg, pool);
     assert_eq!(p.wait_done(gen), None, "fault");
 }
 
 /// fan-out: op0 (1 slice) → op1..op4 (4 slices each) → op5 (1 slice) waits on all.
 fn fan_ops() -> Vec<Op> {
-    let mut ops = vec![Op { blocks: 1, deps: vec![], seg: 0 }];
+    let mut ops = vec![Op {
+        blocks: 1,
+        deps: vec![],
+        seg: 0,
+    }];
     for _ in 0..4 {
-        ops.push(Op { blocks: 4, deps: vec![0], seg: 0 });
+        ops.push(Op {
+            blocks: 4,
+            deps: vec![0],
+            seg: 0,
+        });
     }
-    ops.push(Op { blocks: 1, deps: vec![1, 2, 3, 4], seg: 0 });
+    ops.push(Op {
+        blocks: 1,
+        deps: vec![1, 2, 3, 4],
+        seg: 0,
+    });
     ops
 }
 
@@ -216,10 +240,26 @@ fn diamond_ops() -> Vec<Op> {
     let mut prev: Option<usize> = None;
     for _ in 0..8 {
         let a = ops.len();
-        ops.push(Op { blocks: 6, deps: prev.into_iter().collect(), seg: 0 });
-        ops.push(Op { blocks: 6, deps: vec![a], seg: 0 });
-        ops.push(Op { blocks: 6, deps: vec![a], seg: 0 });
-        ops.push(Op { blocks: 6, deps: vec![a + 1, a + 2], seg: 0 });
+        ops.push(Op {
+            blocks: 6,
+            deps: prev.into_iter().collect(),
+            seg: 0,
+        });
+        ops.push(Op {
+            blocks: 6,
+            deps: vec![a],
+            seg: 0,
+        });
+        ops.push(Op {
+            blocks: 6,
+            deps: vec![a],
+            seg: 0,
+        });
+        ops.push(Op {
+            blocks: 6,
+            deps: vec![a + 1, a + 2],
+            seg: 0,
+        });
         prev = Some(a + 3);
     }
     ops
@@ -243,7 +283,11 @@ fn static_mode_orders_dependencies_on_every_thread_count() {
                 run_once(&p, &prog, &ctr, 0, &rec);
                 assert_eq!(rec.count.load(Ordering::Relaxed), total_slices(&ops));
             }
-            assert_eq!(rec.violations.load(Ordering::Relaxed), 0, "threads={threads}");
+            assert_eq!(
+                rec.violations.load(Ordering::Relaxed),
+                0,
+                "threads={threads}"
+            );
         }
     }
 }
@@ -265,6 +309,48 @@ fn threads_fewer_than_cus_does_not_deadlock() {
     assert_eq!(rec.violations.load(Ordering::Relaxed), 0);
 }
 
+/// Records which OS thread served each run. `ThreadId`s are unique for the lifetime of a thread,
+/// so an identical set across many runs is direct evidence the pool never respawned one.
+#[derive(Default)]
+struct Threads(std::sync::Mutex<std::collections::HashSet<std::thread::ThreadId>>);
+
+impl Exec for Threads {
+    fn exec(&self, _inst: &DevInst64, _slice: u32, _nblk: u32, _w: &WorkerCtx) {
+        self.0.lock().unwrap().insert(std::thread::current().id());
+    }
+}
+
+/// Workers are PERSISTENT: spawned once and returned to the control loop, never re-created per
+/// run. `p.threads()` only counts join handles, which cannot change, so this checks the identity
+/// of the threads that actually ran the work — the same set, every run, for every width.
+#[test]
+fn the_same_os_threads_serve_every_run() {
+    let ops = fan_ops();
+    let (prog, ctrs) = build(&ops, 8, 1, 0);
+    let prog = Arc::new(prog);
+    let ctr = Arc::new(CounterPool::from_counters(&ctrs));
+    for threads in [1usize, 4, 8] {
+        let rec = Arc::new(Threads::default());
+        let p = pool(threads, 8, rec.clone());
+        let mut first: Option<std::collections::HashSet<_>> = None;
+        for i in 0..200 {
+            rec.0.lock().unwrap().clear();
+            let gen = p.run(&prog, 0, &ctr);
+            assert_eq!(p.wait_done(gen), None, "fault on run {i}");
+            ctr.reset_all();
+            let seen = rec.0.lock().unwrap().clone();
+            assert!(!seen.is_empty(), "run {i} executed nothing");
+            match &first {
+                None => first = Some(seen),
+                Some(f) => assert_eq!(&seen, f, "run {i} ran on a different thread set"),
+            }
+        }
+        // Every worker that ever ran is one of the pool's own, and no more than the pool has.
+        assert!(first.unwrap().len() <= threads);
+        assert_eq!(p.threads(), threads);
+    }
+}
+
 /// A locality plan moves WHERE a cu runs, never WHAT runs: every slice still executes exactly
 /// once and no dependency inverts, at any thread count. The plans are supplied directly so the
 /// check does not depend on how many NUMA nodes the test host happens to have — an out-of-range
@@ -276,9 +362,9 @@ fn a_locality_plan_changes_placement_but_not_execution() {
     let prog = Arc::new(prog);
     let ctr = Arc::new(CounterPool::from_counters(&ctrs));
     let plans: [(Vec<u32>, u32); 3] = [
-        (vec![0; 16], 2),                             // every cu onto one node
-        ((0..16).map(|cu| cu % 2).collect(), 2),      // interleaved groups
-        ((0..16).map(|cu| cu / 2).collect(), 8),      // blocked, more groups than nodes
+        (vec![0; 16], 2),                        // every cu onto one node
+        ((0..16).map(|cu| cu % 2).collect(), 2), // interleaved groups
+        ((0..16).map(|cu| cu / 2).collect(), 8), // blocked, more groups than nodes
     ];
     for (plan, domains) in plans {
         for threads in [1usize, 3, 16] {
@@ -298,7 +384,11 @@ fn a_locality_plan_changes_placement_but_not_execution() {
                 run_once(&p, &prog, &ctr, 0, &rec);
                 assert_eq!(rec.count.load(Ordering::Relaxed), total_slices(&ops));
             }
-            assert_eq!(rec.violations.load(Ordering::Relaxed), 0, "threads={threads}");
+            assert_eq!(
+                rec.violations.load(Ordering::Relaxed),
+                0,
+                "threads={threads}"
+            );
         }
     }
 }
@@ -318,7 +408,11 @@ fn global_queue_two_domains_orders_dependencies() {
             run_once(&p, &prog, &ctr, 0, &rec);
             assert_eq!(rec.count.load(Ordering::Relaxed), total_slices(&ops));
         }
-        assert_eq!(rec.violations.load(Ordering::Relaxed), 0, "threads={threads}");
+        assert_eq!(
+            rec.violations.load(Ordering::Relaxed),
+            0,
+            "threads={threads}"
+        );
     }
 }
 
@@ -326,10 +420,26 @@ fn global_queue_two_domains_orders_dependencies() {
 fn segments_run_one_at_a_time_with_seg_filter() {
     // seg 0: op0 → op1 ; seg 1: op2 (depends on op1) → op3.
     let ops = vec![
-        Op { blocks: 4, deps: vec![], seg: 0 },
-        Op { blocks: 4, deps: vec![0], seg: 0 },
-        Op { blocks: 4, deps: vec![1], seg: 1 },
-        Op { blocks: 4, deps: vec![2], seg: 1 },
+        Op {
+            blocks: 4,
+            deps: vec![],
+            seg: 0,
+        },
+        Op {
+            blocks: 4,
+            deps: vec![0],
+            seg: 0,
+        },
+        Op {
+            blocks: 4,
+            deps: vec![1],
+            seg: 1,
+        },
+        Op {
+            blocks: 4,
+            deps: vec![2],
+            seg: 1,
+        },
     ];
     let (prog, ctrs) = build(&ops, 8, 2, 0);
     let prog = Arc::new(prog);
@@ -338,7 +448,8 @@ fn segments_run_one_at_a_time_with_seg_filter() {
     let p = pool(4, 8, rec.clone());
     rec.reset();
     ctr.reset_all();
-    rec.base.store(prog.insts.as_ptr() as usize, Ordering::Release);
+    rec.base
+        .store(prog.insts.as_ptr() as usize, Ordering::Release);
     let g = p.run(&prog, 0, &ctr);
     assert_eq!(p.wait_done(g), None);
     assert_eq!(rec.count.load(Ordering::Relaxed), 8, "only seg 0 ran");
@@ -353,7 +464,11 @@ fn segments_run_one_at_a_time_with_seg_filter() {
 fn cancel_returns_pool_to_idle_and_next_run_completes() {
     // A long serial chain with a slow mock: cancel early, then run fully.
     let ops: Vec<Op> = (0..64)
-        .map(|k| Op { blocks: 1, deps: if k == 0 { vec![] } else { vec![k - 1] }, seg: 0 })
+        .map(|k| Op {
+            blocks: 1,
+            deps: if k == 0 { vec![] } else { vec![k - 1] },
+            seg: 0,
+        })
         .collect();
     let (prog, ctrs) = build(&ops, 4, 1, 0);
     let prog = Arc::new(prog);
@@ -362,13 +477,17 @@ fn cancel_returns_pool_to_idle_and_next_run_completes() {
     let p = pool(4, 4, rec.clone());
     rec.reset();
     ctr.reset_all();
-    rec.base.store(prog.insts.as_ptr() as usize, Ordering::Release);
+    rec.base
+        .store(prog.insts.as_ptr() as usize, Ordering::Release);
     let g = p.run(&prog, 0, &ctr);
     std::thread::sleep(Duration::from_millis(5));
     p.cancel(g);
     assert_eq!(p.wait_done(g), None);
     let partial = rec.count.load(Ordering::Relaxed);
-    assert!(partial < 64, "cancel should stop the chain early, ran {partial}");
+    assert!(
+        partial < 64,
+        "cancel should stop the chain early, ran {partial}"
+    );
     // Pool is idle and reusable.
     rec.reset();
     run_once(&p, &prog, &ctr, 0, &rec);
@@ -387,7 +506,8 @@ fn drop_cancels_an_inflight_run() {
     let prog = Arc::new(prog);
     let ctr = Arc::new(CounterPool::from_counters(&ctrs));
     let rec = Arc::new(Recorder::new(&ops, Duration::ZERO));
-    rec.base.store(prog.insts.as_ptr() as usize, Ordering::Release);
+    rec.base
+        .store(prog.insts.as_ptr() as usize, Ordering::Release);
     let p = pool(1, 1, rec);
     p.run(&prog, 0, &ctr);
 
@@ -408,7 +528,13 @@ fn reset_slot_zeroes_through_workers() {
     let mut buf = vec![0xFFu8; 1 << 20];
     let mut buf2 = vec![0xAAu8; 12345];
     unsafe {
-        p.reset_slot(3, &[(buf.as_mut_ptr(), buf.len()), (buf2.as_mut_ptr(), buf2.len())]);
+        p.reset_slot(
+            3,
+            &[
+                (buf.as_mut_ptr(), buf.len()),
+                (buf2.as_mut_ptr(), buf2.len()),
+            ],
+        );
     }
     assert!(buf.iter().all(|&b| b == 0));
     assert!(buf2.iter().all(|&b| b == 0));
@@ -426,7 +552,11 @@ fn pool_persists_across_many_runs() {
     for i in 0..1000 {
         rec.reset();
         run_once(&p, &prog, &ctr, 0, &rec);
-        assert_eq!(rec.count.load(Ordering::Relaxed), total_slices(&ops), "run {i}");
+        assert_eq!(
+            rec.count.load(Ordering::Relaxed),
+            total_slices(&ops),
+            "run {i}"
+        );
         // Every worker reported done ⇒ every thread is still alive.
         assert_eq!(p.feedback().done.load(Ordering::Acquire), 8);
     }
@@ -438,11 +568,23 @@ fn pool_persists_across_many_runs() {
 fn topology_fixture_and_detect() {
     let t = Topology::from_sysfs_text(
         "0-7",
-        &[(0, "0,4"), (1, "1,5"), (2, "2,6"), (3, "3,7"), (4, "0,4"), (5, "1,5"), (6, "2,6"), (7, "3,7")],
+        &[
+            (0, "0,4"),
+            (1, "1,5"),
+            (2, "2,6"),
+            (3, "3,7"),
+            (4, "0,4"),
+            (5, "1,5"),
+            (6, "2,6"),
+            (7, "3,7"),
+        ],
         &[(0, "0-1,4-5"), (1, "2-3,6-7")],
     );
     assert_eq!(t.physical_cores(), 4);
-    assert_eq!(t.cores_on_node(1).map(|c| c.cpu).collect::<Vec<_>>(), vec![2, 3]);
+    assert_eq!(
+        t.cores_on_node(1).map(|c| c.cpu).collect::<Vec<_>>(),
+        vec![2, 3]
+    );
     let live = Topology::detect();
     assert!(live.physical_cores() >= 1);
     assert!(!live.nodes.is_empty());

--- a/crates/plowrt/tests/cpu_interp.rs
+++ b/crates/plowrt/tests/cpu_interp.rs
@@ -190,7 +190,7 @@ impl Recorder {
 
 fn pool(threads: usize, n_cu: u32, exec: Arc<dyn Exec>) -> WorkerPool {
     let topo = Topology::detect();
-    WorkerPool::spawn(&topo, threads, &NumaMode::Off, 20, n_cu, exec)
+    WorkerPool::spawn(&topo, threads, &NumaMode::Off, 20, n_cu, None, exec)
 }
 
 fn run_once(p: &WorkerPool, prog: &Arc<LoadedProgram>, pool: &Arc<CounterPool>, seg: u32, rec: &Recorder) {
@@ -263,6 +263,44 @@ fn threads_fewer_than_cus_does_not_deadlock() {
         assert_eq!(rec.count.load(Ordering::Relaxed), total_slices(&ops));
     }
     assert_eq!(rec.violations.load(Ordering::Relaxed), 0);
+}
+
+/// A locality plan moves WHERE a cu runs, never WHAT runs: every slice still executes exactly
+/// once and no dependency inverts, at any thread count. The plans are supplied directly so the
+/// check does not depend on how many NUMA nodes the test host happens to have — an out-of-range
+/// node index in a plan has to fold safely rather than drop the cu.
+#[test]
+fn a_locality_plan_changes_placement_but_not_execution() {
+    let ops = diamond_ops();
+    let (prog, ctrs) = build(&ops, 16, 1, 0);
+    let prog = Arc::new(prog);
+    let ctr = Arc::new(CounterPool::from_counters(&ctrs));
+    let plans: [(Vec<u32>, u32); 3] = [
+        (vec![0; 16], 2),                             // every cu onto one node
+        ((0..16).map(|cu| cu % 2).collect(), 2),      // interleaved groups
+        ((0..16).map(|cu| cu / 2).collect(), 8),      // blocked, more groups than nodes
+    ];
+    for (plan, domains) in plans {
+        for threads in [1usize, 3, 16] {
+            let rec = Arc::new(Recorder::new(&ops, Duration::ZERO));
+            let topo = Topology::detect();
+            let p = WorkerPool::spawn(
+                &topo,
+                threads,
+                &NumaMode::Off,
+                20,
+                16,
+                Some((&plan, domains)),
+                rec.clone(),
+            );
+            for _ in 0..20 {
+                rec.reset();
+                run_once(&p, &prog, &ctr, 0, &rec);
+                assert_eq!(rec.count.load(Ordering::Relaxed), total_slices(&ops));
+            }
+            assert_eq!(rec.violations.load(Ordering::Relaxed), 0, "threads={threads}");
+        }
+    }
 }
 
 #[test]

--- a/docs/flags-reference.md
+++ b/docs/flags-reference.md
@@ -762,6 +762,34 @@ values cost.
 
 ---
 
+## CPU runtime knobs (`plowrt --cpu-*`)
+
+Only present in a build carrying the `cpu` feature. Every one is a CLI flag with an
+environment twin, and the CLI wins. Full prose, plus how to compile a CPU-loadable
+bundle in the first place, in [CPU execution](runtime/cpu.md).
+
+| flag | env | default | effect |
+|---|---|---|---|
+| `--cpu-threads N` | `PLOW_CPU_THREADS` | 0 | Persistent kernel workers. `0` = model-dependent width (physical cores for MoE, logical CPUs for dense decode). Independent of the packet's `--n-cu`: the pool maps any thread count onto the virtual executors, so one bundle serves any core count. |
+| `--cpu-numa MODE` | `PLOW_CPU_NUMA` | `auto` | `auto` interleaves large tensors across allowed nodes (best effort); `off` keeps OS/`numactl` policy; `0,1` requires successful binding and rejects unavailable nodes. Topology honours cpusets and `taskset`. |
+| `--cpu-isa TIER` | `PLOW_CPU_ISA` | `auto` | Tier ceiling `scalar` / `avx512` / `amx`. Never activates above what cpuid and OS register state permit, so this only ever narrows. |
+| `--cpu-huge-pages=B` | `PLOW_CPU_HUGE_PAGES` | unset | Override THP *advice* (default: ordinary pages when interleaved, huge-page advice for single-node/OS placement). Advice only — not the system THP setting. |
+| `--cpu-spin-us N` | `PLOW_CPU_SPIN_US` | 2000 | Spin budget (µs) before a blocked worker yields and parks. Decode packets are 100–500 µs apart; parking every gap measured **+17% TPOT** at 50 µs vs 1000. |
+| `--cpu-prefill-chunk N` | `PLOW_CPU_PF_CHUNK` | 0 (off) | Largest prefill chunk (rows) a tick may run while other slots decode. Measured **negative at concurrency ≥ 4** — the threads are throughput-bound, not stall-bound — so it stays off. |
+| `--cpu-mxfp4-dir DIR` | `PLOW_MXFP4_DIR` | unset | MXFP4 weight twin (`mxfp4/<name>` + `_scale` E8M0 rows; `perf-data/tools/quantize_mxfp4.py`). |
+| `--fp8-dir DIR` | `PLOW_FP8_DIR` | unset | fp8 weight twin. Runtime-wide, but this is how a CPU bundle gets W8A16/W8A8 weights. |
+| `--cpu-global-queue=B` | `PLOW_CPU_GQ` | off | Global op-major work queue (windowed per segment and L2 domain, with stealing) instead of static per-cu streams. **~2x slower** on the EPYC 9654; kept for A/B. |
+| `--cpu-l2-place=B` | `PLOW_CPU_L2_PLACE` | off | Place executors by the packet's L2 locality domains instead of `cu % nodes`. **1.5x slower**, never faster ([report](../perf-data/cpu-numa-placement/epyc9654-avx512/README.md)). Inert without domains in the blob; a balance guard declines a losing plan even when on. |
+
+The last two are off because they were *measured* worse, not because they are
+unfinished — neither changes what is computed, so both are safe to flip for an A/B
+on another host.
+
+Compile-side, there is no CPU emit target: `plowc` emits for a device target and the
+CPU interprets that packet. Use an **NVIDIA** `--gpu` (a gfx942/gfx950 packet is
+rejected at load), and set `--n-cu` explicitly — it is the virtual executor count,
+capped at 256, and need not match any thread count.
+
 ## Serving / runtime knobs (`plowrt` env)
 
 | var | default | effect |

--- a/docs/runtime/cpu.md
+++ b/docs/runtime/cpu.md
@@ -20,6 +20,71 @@ physical cores for MoE; logical CPUs for dense decode. An explicit count overrid
 that choice. Each loaded model owns a pool; budget threads across concurrently
 served models. A CPU-only build does not probe or link CUDA/HSA drivers.
 
+## Compiling a bundle
+
+There is no CPU emit target. `plowc` always compiles for a *device* target and the
+CPU backend interprets the resulting packet, so the interpreter-object step of the
+GPU quickstart is skipped entirely — a CPU bundle is `model.pkt`, its manifest, and
+a tokenizer, with no cubin or hsaco.
+
+```sh
+CKPT=/path/to/gemma-4-12B-it
+target/release/plowc --hf-dir "$CKPT" \
+  --gpu rtx6000pro --n-cu 96 --max-ctx 2048 \
+  --batch 1,4 --seq 128,512 --out /path/to/bundle
+```
+
+Pick an **NVIDIA** target. A gfx942/gfx950 packet carries AMD-specific fusion the
+CPU kernels do not implement and is rejected at load, typically as a KV-row site
+past the decode program's instruction count. `rtx6000pro` is what the bundles in
+`perf-data/cpu-*` were built with; the `--gpu` default is `h100`.
+
+`--n-cu` is the packet's count of *virtual* executors, not a thread count. Kernels
+take "the `slice`-th of `nblk` shares", and the worker pool maps whatever thread
+count it has onto those executors: a worker owns several when threads are fewer,
+and tail workers own none when threads are more. **One bundle therefore serves any
+core count**, and `--cpu-threads` is free to differ from `--n-cu` — 96 executors on
+192 threads is a normal configuration. Compile once at a width that divides the
+largest machine you intend to serve; the emitter caps `--n-cu` at 256, because the
+per-domain slice count is a nine-bit field. Leaving it at `0` takes the `--gpu`
+spec's SM/CU count, which is why an explicit value is usually the better choice
+for CPU.
+
+Emit-time choices the CPU loader constrains:
+
+| choice | why |
+| --- | --- |
+| `--qnorm-fuse` (default off) | leave it off for W8A8; CPU loading rejects that RMSNorm fusion |
+| `--max-ctx` | sizes the KV cache, which is host RAM here — the 2048 above is a bench setting, not a serving one |
+| `--batch` / `--seq` | the compiled prefill buckets and decode rungs; a bundle with no grouped-prefill program prefills one token at a time |
+| MXFP4 | `--gpu` must be a target that permits it at emit; the twin is supplied at run time with `--cpu-mxfp4-dir` |
+
+## Flags
+
+Every CPU runtime knob is a `--cpu-*` flag with a `PLOW_CPU_*` environment twin;
+the CLI wins over the environment. `plowrt serve --help` prints them under the
+"CPU runtime" heading.
+
+| flag | env | default | effect |
+| --- | --- | --- | --- |
+| `--cpu-threads N` | `PLOW_CPU_THREADS` | `0` | Persistent workers. `0` selects the model-dependent width: physical cores for MoE, logical CPUs for dense decode. Need not equal `--n-cu`. |
+| `--cpu-numa MODE` | `PLOW_CPU_NUMA` | `auto` | `auto` interleaves large tensors across the allowed nodes (best effort); `off` keeps the OS policy, including an external `numactl`; a list such as `0,1` requires successful placement and rejects unavailable nodes. |
+| `--cpu-isa TIER` | `PLOW_CPU_ISA` | `auto` | Kernel tier ceiling: `scalar`, `avx512`, `amx`. For A/B, and for hosts without AMX. Never activates above what cpuid and OS state permit. |
+| `--cpu-huge-pages=B` | `PLOW_CPU_HUGE_PAGES` | unset | Override transparent-huge-page *advice*: by default ordinary pages for interleaved tensors, huge-page advice for single-node or OS placement. Changes advice, not the system THP setting. |
+| `--cpu-spin-us N` | `PLOW_CPU_SPIN_US` | `2000` | Spin budget (µs) before a blocked worker yields and parks. Decode packets are 100–500 µs apart; parking on every gap measured **+17% TPOT** at 50 µs versus 1000. |
+| `--cpu-prefill-chunk N` | `PLOW_CPU_PF_CHUNK` | `0` | Largest prefill chunk (rows) one tick may run while other slots decode; `0` = whole prompt. Measured **negative** at concurrency ≥ 4, so it stays off. |
+| `--cpu-mxfp4-dir DIR` | `PLOW_MXFP4_DIR` | unset | Directory holding the MXFP4 weight twin (`mxfp4/<name>` plus `_scale` rows, from `perf-data/tools/quantize_mxfp4.py`). |
+| `--fp8-dir DIR` | `PLOW_FP8_DIR` | unset | The fp8 weight twin. Runtime-wide rather than CPU-specific, but this is how a CPU bundle gets W8A16/W8A8 weights. |
+| `--cpu-global-queue=B` | `PLOW_CPU_GQ` | `false` | Take the blob's op-major global work queue, windowed per segment and locality domain, instead of static per-cu streams. **Measured ~2x slower** on the EPYC 9654; kept for A/B where the static partition is a poor fit. |
+| `--cpu-l2-place=B` | `PLOW_CPU_L2_PLACE` | `false` | Place executors by the packet's L2 locality domains instead of `cu % nodes`. **Measured 1.5x slower** and never faster — see the [placement report](../../perf-data/cpu-numa-placement/epyc9654-avx512/README.md). Inert on a blob carrying no domains, and the balance guard declines a losing plan even when this is on. |
+
+The last two default to off because they were measured worse, not because they are
+unfinished. Both are safe to flip for an A/B on a different host; neither changes
+what is computed.
+
+`--executors` (not CPU-specific) sizes the reference interpreter. Each loaded model
+owns its own worker pool, so budget threads across concurrently served models.
+
 ## ISA coverage
 
 The x86-64 scalar code stays at the baseline ISA. Runtime detection checks OS

--- a/docs/runtime/cpu.md
+++ b/docs/runtime/cpu.md
@@ -81,22 +81,30 @@ therefore serves any core count, and `n_cu` never has to match it. Compile once
 at a width that divides the largest core count you intend to serve; the emitter
 caps `n_cu` at 256, because the per-domain slice count is a nine-bit field.
 
-Executors are then assigned to nodes from the packet's L2 locality domains when
-the blob carries them (`PLOW_L2_PLACE`), so cus that feed each other share a
-node. Domains are read back from the per-entry domain bits, which makes the
-recovery independent of the emitter's workgroup-to-domain map. The domain is a
-relative hint, never a node id: the mapping onto real nodes happens at load,
-where the host topology is known, which is what keeps one blob portable across
-hosts with different node counts. Each worker's first global-queue claim follows
-the same assignment instead of its bare node index.
+Executors are placed on node `cu % nodes`. Placing them by the packet's L2
+locality domains instead is implemented behind `--cpu-l2-place` and is **off**,
+because it measured 1.5x slower and never faster; see the
+[placement report](../../perf-data/cpu-numa-placement/epyc9654-avx512/README.md).
 
-Placement falls back to the previous `cu % nodes` round-robin whenever the blob
-expresses no usable locality: no `PLOW_L2_PLACE`, the legacy layout that encoded
-the domain in `seg`, a single node or domain, placed programs that disagree, or
-domains that do not divide evenly over the nodes. The last case is deliberate —
-spreading over every node is the larger measured effect, so an uneven split is
-not traded for locality. An unplaced program alongside a placed one is
-indifferent to the choice and simply follows it.
+The reason is worth keeping, because the idea is superficially attractive. An L2
+domain says which slices share a *GPU* cache. It does not say which weights they
+touch, and CPU model tensors are interleaved across every node regardless — so
+grouping by domain creates no memory locality on this engine. It does destroy the
+round-robin's load balance, because nothing makes domains equal in cost: under the
+blocked map (`cu / sms_per_partition`) the low-numbered cus carry every narrowly
+sliced op, so one node inherits a third of the packet. On an H100-mapped
+Gemma-4-31B that is a 3.0-4.1x work spread across nodes against round-robin's
+1.04-1.12x.
+
+The mechanism is kept, tested, and A/B-able because it costs nothing when off and
+a host with balanced domains has not been measured. When it is on, `node_plan`
+still declines any plan that would leave a node busier than the round-robin
+would, which is what rejects the case above; it also declines when the blob
+carries no domains, when the legacy layout encoded the domain in `seg`, on a
+single node or domain, when placed programs disagree, and when the domains do not
+divide evenly over the nodes. Under the AMD round-robin map the plan reduces to
+`cu % nodes` exactly whenever the domain count equals the node count, so on an
+8-node host an 8-XCD blob would see no difference either way.
 
 | Setting | Workers | Large model tensors |
 | --- | --- | --- |
@@ -117,13 +125,12 @@ or tensor allocation is added to a kernel invocation.
 This is a shared-memory engine with interleaved tensors, not NUMA tensor parallelism.
 It does not replicate weights or KV by socket, nor use remote-node work stealing
 outside the global queue's own stealing. Those require model-level measurements and
-a matching compiler/runtime ownership design. Executor placement follows the packet's
-locality domains, but the packet still carries no host topology and the compiler emits
-none: a blob is never built for a particular node count. Interleave requests balanced
-page placement; allocation fallback can still concentrate physical pages on fewer
-nodes. Domain-following placement is a locality hint acted on at load, not a guarantee
-of local access or of a multi-socket inference speedup; it is not yet measured against
-the round-robin on a placed blob.
+a matching compiler/runtime ownership design. The packet carries no host topology and
+the compiler emits none: a blob is never built for a particular node count, and
+executor placement is decided at load. Interleave requests balanced page placement;
+allocation fallback can still concentrate physical pages on fewer nodes. It does not
+guarantee local access or a multi-socket inference speedup, and following the packet's
+locality domains measured slower rather than faster.
 
 ## Verification on EPYC 9654
 

--- a/docs/runtime/cpu.md
+++ b/docs/runtime/cpu.md
@@ -99,7 +99,11 @@ Gemma-4-31B that is a 3.0-4.1x work spread across nodes against round-robin's
 The mechanism is kept, tested, and A/B-able because it costs nothing when off and
 a host with balanced domains has not been measured. When it is on, `node_plan`
 still declines any plan that would leave a node busier than the round-robin
-would, which is what rejects the case above; it also declines when the blob
+would in ANY ONE PROGRAM, which is what rejects the case above. The per-program
+test is the load-bearing part: programs are alternatives — a prefill bucket or
+the decode program per dispatch — so a plan has to be safe for each separately,
+and testing their summed work instead would let one program's ruin hide behind
+another that leans the other way. It also declines when the blob
 carries no domains, when the legacy layout encoded the domain in `seg`, on a
 single node or domain, when placed programs disagree, and when the domains do not
 divide evenly over the nodes. Under the AMD round-robin map the plan reduces to

--- a/docs/runtime/cpu.md
+++ b/docs/runtime/cpu.md
@@ -15,9 +15,10 @@ target/release/plowrt serve --assets /path/to/bundle \
 ```
 
 `--executors` controls the reference interpreter. Use `--cpu-threads` for the
-persistent CPU kernel workers. Zero selects the existing model-dependent width:
-physical cores for MoE; logical CPUs for dense decode. An explicit count overrides
-that choice. Each loaded model owns a pool; budget threads across concurrently
+persistent CPU kernel workers. Zero selects the model-dependent width — physical
+cores for MoE, logical CPUs for dense decode — then caps it at the packet's `--n-cu`,
+because a worker past that owns no work in any program and only costs its spin. An
+explicit count overrides both. Each loaded model owns a pool; budget threads across concurrently
 served models. A CPU-only build does not probe or link CUDA/HSA drivers.
 
 ## Compiling a bundle
@@ -43,8 +44,9 @@ past the decode program's instruction count. `rtx6000pro` is what the bundles in
 take "the `slice`-th of `nblk` shares", and the worker pool maps whatever thread
 count it has onto those executors: a worker owns several when threads are fewer,
 and tail workers own none when threads are more. **One bundle therefore serves any
-core count**, and `--cpu-threads` is free to differ from `--n-cu` — 96 executors on
-192 threads is a normal configuration. Compile once at a width that divides the
+core count**, and `--cpu-threads` need not match `--n-cu`. Fewer threads than
+executors is the normal and cheap direction; more is not, since the surplus workers
+own nothing, so the automatic width caps itself at `--n-cu`. Compile once at a width that divides the
 largest machine you intend to serve; the emitter caps `--n-cu` at 256, because the
 per-domain slice count is a nine-bit field. Leaving it at `0` takes the `--gpu`
 spec's SM/CU count, which is why an explicit value is usually the better choice
@@ -67,7 +69,7 @@ the CLI wins over the environment. `plowrt serve --help` prints them under the
 
 | flag | env | default | effect |
 | --- | --- | --- | --- |
-| `--cpu-threads N` | `PLOW_CPU_THREADS` | `0` | Persistent workers. `0` selects the model-dependent width: physical cores for MoE, logical CPUs for dense decode. Need not equal `--n-cu`. |
+| `--cpu-threads N` | `PLOW_CPU_THREADS` | `0` | Persistent workers. `0` selects the model-dependent width (physical cores for MoE, logical CPUs for dense decode), capped at the packet's `--n-cu`. May be set above `--n-cu`, but the surplus workers own nothing and cost their spin — measured **8.3x** on decode at 240 idle workers. |
 | `--cpu-numa MODE` | `PLOW_CPU_NUMA` | `auto` | `auto` interleaves large tensors across the allowed nodes (best effort); `off` keeps the OS policy, including an external `numactl`; a list such as `0,1` requires successful placement and rejects unavailable nodes. |
 | `--cpu-isa TIER` | `PLOW_CPU_ISA` | `auto` | Kernel tier ceiling: `scalar`, `avx512`, `amx`. For A/B, and for hosts without AMX. Never activates above what cpuid and OS state permit. |
 | `--cpu-huge-pages=B` | `PLOW_CPU_HUGE_PAGES` | unset | Override transparent-huge-page *advice*: by default ordinary pages for interleaved tensors, huge-page advice for single-node or OS placement. Changes advice, not the system THP setting. |

--- a/docs/runtime/cpu.md
+++ b/docs/runtime/cpu.md
@@ -86,18 +86,26 @@ locality domains instead is implemented behind `--cpu-l2-place` and is **off**,
 because it measured 1.5x slower and never faster; see the
 [placement report](../../perf-data/cpu-numa-placement/epyc9654-avx512/README.md).
 
-The reason is worth keeping, because the idea is superficially attractive. An L2
-domain says which slices share a *GPU* cache. It does not say which weights they
-touch, and CPU model tensors are interleaved across every node regardless — so
-grouping by domain creates no memory locality on this engine. It does destroy the
-round-robin's load balance, because nothing makes domains equal in cost: under the
-blocked map (`cu / sms_per_partition`) the low-numbered cus carry every narrowly
-sliced op, so one node inherits a third of the packet. On an H100-mapped
-Gemma-4-31B that is a 3.0-4.1x work spread across nodes against round-robin's
-1.04-1.12x.
+The reason is worth keeping, because the idea is superficially attractive and the
+obvious rescue does not work. An L2 domain says which slices share a *GPU* cache.
+It does not say which weights they touch, and CPU model tensors are `mbind`
+interleaved across every node regardless — a weight read is ~1/8 local wherever
+the reading thread sits, so grouping by domain creates no memory locality here.
 
-The mechanism is kept, tested, and A/B-able because it costs nothing when off and
-a host with balanced domains has not been measured. When it is on, `node_plan`
+What it does cost is concurrency. A contiguous domain map confines a k-slice op to
+`ceil(k / sms_per_partition)` nodes, and ops are not all full width: in one
+Gemma-4-31B prefill program `GEMM` is 291 instructions averaging 89.6 of 144
+slices, so those run on 5 of 8 nodes while the round-robin spreads them over all
+8. Summed per node the two look balanced — 0.14% apart on that blob — while every
+barrier still waits on a narrower machine, and placement measured 1.24x slower
+anyway. Balancing the domains does not rescue it, because the narrowing is in the
+map's contiguity, not in how domains are assigned to nodes.
+
+The mechanism is kept, tested, and A/B-able because it costs nothing when off, not
+because a win is expected: balanced domains were measured and still lost. What has
+not been tried is the AMD round-robin domain map, which spreads each op across
+nodes rather than narrowing it, and so is the shape most likely to come out
+neutral. When placement is on, `node_plan`
 still declines any plan that would leave a node busier than the round-robin
 would in ANY ONE PROGRAM, which is what rejects the case above. The per-program
 test is the load-bearing part: programs are alternatives — a prefill bucket or

--- a/docs/runtime/cpu.md
+++ b/docs/runtime/cpu.md
@@ -36,8 +36,10 @@ subnormals and NaNs. MXFP4 uses the existing packed even-K row layout and E8M0
 block scales. Packet tile/slice ownership is preserved.
 
 `QUANT_FP8` supports per-row BF16-to-e4m3fn activation quantization with FP32
-scales, round-to-nearest ties-to-even, and finite saturation. Its ordinary path
-uses AVX-512; fused gate/up activation uses the scalar reference. Compile W8A8
+scales, round-to-nearest ties-to-even, and finite saturation. Both its ordinary
+path and its fused gate/up activation use AVX-512; the fused form computes the
+activation, the bf16 store, and the row maximum in one pass, measuring 9.7-13.4x
+its scalar reference on one EPYC 9654 core. Compile W8A8
 without `--qnorm-fuse`: CPU loading rejects that unsupported RMSNorm fusion.
 W8A16 uses FP8 weights and BF16 activations; neither mode requires native FP8
 arithmetic instructions. Gemma FP8 expert GLU/down kernels have scalar and
@@ -54,7 +56,12 @@ assets; tensor-handle validation is not a complete sandbox for hostile packets.
 
 Vector reductions can differ from sequential f32 accumulation. Kernel tests use
 numerical tolerances and independent references where available; bit-identical
-generated text across ISA tiers is not promised. Existing optional INT8/INT16 MoE
+generated text across ISA tiers is not promised. The vector gelu evaluates
+`0.5*x*(1 + tanh(c))` in its equivalent `x * sigmoid(2c)` form, which the scalar
+tier does not: below roughly `x = -4` the `1 + tanh` form cancels down to noise
+and `tanhf` then saturates the scalar tier's output to zero, so the two tiers
+disagree in that tail, on values whose magnitude is far under one fp8 code of the
+row scale. Existing optional INT8/INT16 MoE
 paths and approximate FP8 decode GEMVs retain their earlier accuracy tradeoffs.
 
 ## NUMA policy

--- a/docs/runtime/cpu.md
+++ b/docs/runtime/cpu.md
@@ -71,6 +71,33 @@ and `taskset`. A permitted SMT sibling remains usable when its lower-numbered
 sibling is excluded. Worker placement alternates nodes at each core position,
 then places SMT siblings. Worker metadata uses the same placement list.
 
+### Executor placement
+
+The packet fixes how work is *divided* — `n_cu` virtual executors, each kernel
+computing the `slice`-th of `nblk` shares — but not where those executors run.
+A pool of any width covers them: a worker owns several cus when there are fewer
+threads than cus, and tail workers own none when there are more. One blob
+therefore serves any core count, and `n_cu` never has to match it. Compile once
+at a width that divides the largest core count you intend to serve; the emitter
+caps `n_cu` at 256, because the per-domain slice count is a nine-bit field.
+
+Executors are then assigned to nodes from the packet's L2 locality domains when
+the blob carries them (`PLOW_L2_PLACE`), so cus that feed each other share a
+node. Domains are read back from the per-entry domain bits, which makes the
+recovery independent of the emitter's workgroup-to-domain map. The domain is a
+relative hint, never a node id: the mapping onto real nodes happens at load,
+where the host topology is known, which is what keeps one blob portable across
+hosts with different node counts. Each worker's first global-queue claim follows
+the same assignment instead of its bare node index.
+
+Placement falls back to the previous `cu % nodes` round-robin whenever the blob
+expresses no usable locality: no `PLOW_L2_PLACE`, the legacy layout that encoded
+the domain in `seg`, a single node or domain, placed programs that disagree, or
+domains that do not divide evenly over the nodes. The last case is deliberate —
+spreading over every node is the larger measured effect, so an uneven split is
+not traded for locality. An unplaced program alongside a placed one is
+indifferent to the choice and simply follows it.
+
 | Setting | Workers | Large model tensors |
 | --- | --- | --- |
 | `auto` | All allowed CPU nodes | Bind on one node, interleave across multiple nodes; report failure and retain OS policy |
@@ -88,11 +115,15 @@ scratch is first touched after pinning to its worker CPU. No memory-policy sysca
 or tensor allocation is added to a kernel invocation.
 
 This is a shared-memory engine with interleaved tensors, not NUMA tensor parallelism.
-It does not replicate weights or KV by socket, change packet ownership, or use
-remote-node work stealing. Those require model-level measurements and a matching
-compiler/runtime ownership design. Interleave requests balanced page placement;
-allocation fallback can still concentrate physical pages on fewer nodes. It does
-not guarantee local access or a multi-socket inference speedup.
+It does not replicate weights or KV by socket, nor use remote-node work stealing
+outside the global queue's own stealing. Those require model-level measurements and
+a matching compiler/runtime ownership design. Executor placement follows the packet's
+locality domains, but the packet still carries no host topology and the compiler emits
+none: a blob is never built for a particular node count. Interleave requests balanced
+page placement; allocation fallback can still concentrate physical pages on fewer
+nodes. Domain-following placement is a locality hint acted on at load, not a guarantee
+of local access or of a multi-socket inference speedup; it is not yet measured against
+the round-robin on a placed blob.
 
 ## Verification on EPYC 9654
 

--- a/perf-data/cpu-numa-placement/epyc9654-avx512/README.md
+++ b/perf-data/cpu-numa-placement/epyc9654-avx512/README.md
@@ -71,13 +71,66 @@ After the guard landed, both settings take the round-robin and become one popula
 (TTFT 6361–8666 ms, step 1100–1520 ms across four runs straddling both flags), which
 is the ±20% noise band this bench actually has at 192 threads.
 
+## Can a change rescue it? No — balance was not the whole cause
+
+The obvious objection to the above is that the losses are load imbalance, not the idea, so
+fix the imbalance and the idea should pay. It does not.
+
+`n_cu = 132` does not divide by the 18 SMs per partition, which left domain 7 with 6 cus
+instead of 18. Recompiling at `--n-cu 144` removes exactly that:
+
+| | n_cu=132 | n_cu=144 |
+| --- | ---: | ---: |
+| emitter skew, prefill | 66.8–75.5% | **0.3%** |
+| placed vs round-robin peak, T=512 | 14131 vs 13328 (6.0% worse) | 14131 vs 14111 (**0.14% worse**) |
+| placed vs round-robin peak, T=1 decode | 7377 vs 5676 (30% worse) | 7377 vs 5977 (23% worse) |
+
+Prefill is now balanced to 0.14%, which makes it a fair test of locality alone. Forcing the
+guard open (a temporary local patch, not a shipped flag) and A/B-ing at prompt 512, 192
+threads:
+
+| rep | placed TTFT ms | RR TTFT ms | placed step ms | RR step ms |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 | 18250.0 | 15286.5 | 1161.0 | 1136.7 |
+| 2 | 18582.7 | 15042.0 | 1094.6 | 1121.4 |
+| 3 | 18999.7 | 14786.8 | 1138.8 | 1151.0 |
+| **mean** | **18610.8** | **15038.4** | **1131.5** | **1136.4** |
+
+**Prefill is still 1.24x slower with the balance objection removed.** Decode became neutral
+(1.00x), which is consistent: at `n_cu = 144` no node is left mostly idle, so the earlier
+1.50x decode loss was the 6-cu node, and what remains in prefill is not imbalance at all.
+
+The reason total balance does not rescue it is that **per-node work balance is not per-op
+concurrency**. Ops do not all span the full width — in the T=512 program `PLOW_DOP_GEMM` is
+291 instructions averaging 89.6 of 144 slices:
+
+```
+     8 PLOW_DOP_GEMM      insts=291   slices=26064     # 89.6 slices per instruction
+     7 PLOW_DOP_SOFTCAP   insts=1     slices=64
+    18 PLOW_DOP_ARGMAX_FIN insts=1    slices=1
+```
+
+A contiguous domain map confines a k-slice op to `ceil(k / 18)` nodes, so a 90-slice GEMM
+runs on 5 of 8 nodes and the other 3 idle through it; the round-robin spreads the same 90
+slices over all 8. Summed over a program those totals even out — hence the 0.14% — while
+every barrier still waits on a narrower machine. No domain-to-node assignment can fix that,
+because the narrowing is in the domain map's contiguity in cu index, not in the assignment.
+
+Nor is there locality to win it back. Model tensors of at least 256 KiB are `mbind`
+interleaved across every node, so a weight read is ~1/8 local wherever the reading thread
+sits — placement cannot change it. Making the idea pay would need the weights placed per
+node to match, which is NUMA tensor parallelism and a different design (see the note at the
+end of the runtime doc).
+
 ## What was NOT measured
 
-* A blob whose domains are balanced. Under the AMD round-robin map the plan reduces
-  to `cu % nodes` exactly when the domain count equals the node count, so an 8-XCD
-  blob on this 8-node host is the identical mapping and cannot show a difference; a
-  node count other than 8 would be needed, and a gfx950 blob does not load on the CPU
-  backend (`KV-row site 689 exceeds decode program 6's 676 instructions`).
+* A blob under the AMD round-robin domain map. It reduces to `cu % nodes` exactly when
+  the domain count equals the node count, so an 8-XCD blob on this 8-node host is the
+  identical mapping and cannot show a difference; a node count other than 8 would be
+  needed, and a gfx950 blob does not load on the CPU backend (`KV-row site 689 exceeds
+  decode program 6's 676 instructions`). Note the round-robin map would also spread each
+  op across nodes, which is the property the blocked map lacks — so it is the shape most
+  likely to come out neutral, not the shape most likely to win.
 * The global-queue path (`PLOW_CPU_GQ=1`), which is itself off by default.
 * Any host that is not this one.
 

--- a/perf-data/cpu-numa-placement/epyc9654-avx512/README.md
+++ b/perf-data/cpu-numa-placement/epyc9654-avx512/README.md
@@ -34,6 +34,13 @@ quantity the makespan follows (`cargo run --example l2_probe -- model.pkt 8`):
 The busiest-node ratio (1.06–1.30x) sets the sign but under-predicts the size of the
 end-to-end loss, so the balance metric is a guard, not a model of the cost.
 
+The guard applies that test **per program**, not to their sum. Programs are
+alternatives — a prefill bucket or the decode program is chosen per dispatch — so each
+one's own busiest node is its own makespan. Summing first is unsound: two programs at
+200/2 and 2/200 across a pair of nodes total 202/202 and look perfectly balanced,
+while each on its own is a 100x spread. `node_plan` takes one work row per program and
+requires every row to hold.
+
 ## Measured
 
 Interleaved A/B (`place=1`, `place=0`, repeated) on one blob, so drift and page-cache
@@ -86,12 +93,18 @@ PLOW_L2_PLACE=1 cargo run --release -p plowc --bin plowc -- \
   --out target/l2-place-on
 ```
 
-Inspect what it carries, and what each node would run under either mapping:
+Inspect what it carries, what each node would run under either mapping, and whether
+the runtime accepts the plan (it reports `CANDIDATE` and `ACCEPTED` separately, and
+calls the engine's own `cu_domains`/`node_plan` so it cannot drift from the decision
+the runtime actually makes):
 
 ```sh
 cargo run --release -p plowrt --no-default-features --features cpu \
   --example l2_probe -- target/l2-place-on/model.pkt 8
 ```
+
+On this blob it prints `ACCEPTED: no` — every one of the four programs has a busier
+peak node under the plan than under the round-robin.
 
 A/B the two placements:
 

--- a/perf-data/cpu-numa-placement/epyc9654-avx512/README.md
+++ b/perf-data/cpu-numa-placement/epyc9654-avx512/README.md
@@ -1,0 +1,112 @@
+# Packet-domain NUMA placement vs `cu % nodes` — EPYC 9654, AVX-512
+
+Following the packet's L2 locality domains when placing CPU executors measured
+**1.5x slower** than the `cu % nodes` round-robin it was meant to improve on, and
+was never faster at any node count tried. It ships **off** (`--cpu-l2-place`,
+`PLOW_CPU_L2_PLACE`), and `node_plan` declines the losing shape even when it is on.
+
+## Why the idea does not pay here
+
+An L2 domain says which slices share a **GPU** cache. It says nothing about which
+weights they touch, and CPU model tensors are interleaved across every node anyway,
+so grouping cus by domain creates no memory locality on this engine.
+
+It does cost the round-robin's balance, because nothing makes domains equal in cost.
+Under the blocked map (`domain = cu / sms_per_partition`) the low-numbered cus carry
+every op that is sliced narrowly, so grouping them puts a third of the packet on one
+node. With `n_cu = 132` over 8 domains of 18 SMs, the last domain also gets a ragged
+6 cus instead of 18:
+
+```
+cus per domain: [18, 18, 18, 18, 18, 18, 18, 6]
+```
+
+Work per node, in stream entries — the unit the static walk executes, and the
+quantity the makespan follows (`cargo run --example l2_probe -- model.pkt 8`):
+
+| program | placed max/min | round-robin max/min | busiest node, placed vs RR |
+| --- | ---: | ---: | ---: |
+| T=128 prefill | 3.79x | 1.04x | 14131 vs 13086 |
+| T=512 prefill | 3.01x | 1.06x | 14131 vs 13328 |
+| T=1024 prefill | 3.01x | 1.06x | 14131 vs 13328 |
+| T=1 decode | 4.08x | 1.12x | 7377 vs 5676 |
+
+The busiest-node ratio (1.06–1.30x) sets the sign but under-predicts the size of the
+end-to-end loss, so the balance metric is a guard, not a model of the cost.
+
+## Measured
+
+Interleaved A/B (`place=1`, `place=0`, repeated) on one blob, so drift and page-cache
+state hit both arms equally.
+
+8 nodes, 192 threads, prompt 128, batch 1:
+
+| rep | placed TTFT ms | RR TTFT ms | placed step ms | RR step ms |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 | 11364.0 | 7535.8 | 1939.6 | 1253.1 |
+| 2 | 11416.5 | 7141.8 | 1872.2 | 1275.9 |
+| 3 | 11237.8 | 7012.8 | 1841.0 | 1243.5 |
+| **mean** | **11339.4** | **7230.1** | **1884.3** | **1257.5** |
+
+**TTFT 1.57x slower, decode step 1.50x slower.** The three repeats span 1.6% (placed)
+and 7.2% (RR), so the gap is far outside run-to-run noise.
+
+2 nodes (`--numa 0,1`), 48 threads:
+
+| rep | placed TTFT ms | RR TTFT ms | placed step ms | RR step ms |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 | 11916.7 | 9686.5 | 1087.1 | 846.5 |
+| 2 | 9999.5 | 9356.0 | 851.5 | 842.7 |
+
+Smaller and noisier — 1.15x TTFT, 1.14x step on the means — but still never faster.
+
+After the guard landed, both settings take the round-robin and become one population
+(TTFT 6361–8666 ms, step 1100–1520 ms across four runs straddling both flags), which
+is the ±20% noise band this bench actually has at 192 threads.
+
+## What was NOT measured
+
+* A blob whose domains are balanced. Under the AMD round-robin map the plan reduces
+  to `cu % nodes` exactly when the domain count equals the node count, so an 8-XCD
+  blob on this 8-node host is the identical mapping and cannot show a difference; a
+  node count other than 8 would be needed, and a gfx950 blob does not load on the CPU
+  backend (`KV-row site 689 exceeds decode program 6's 676 instructions`).
+* The global-queue path (`PLOW_CPU_GQ=1`), which is itself off by default.
+* Any host that is not this one.
+
+## Reproducing
+
+Compile a placed, CPU-loadable blob (H100 is the default `--gpu` and has an 8-GPC L2
+partitioning; `PLOW_L2_PLACE=1` forces placement on a non-CDNA target):
+
+```sh
+PLOW_L2_PLACE=1 cargo run --release -p plowc --bin plowc -- \
+  --hf-dir <gemma4-checkpoint> --gpu h100 \
+  --batch 1,4 --seq 128,512 --max-ctx 2048 --phase both --emit devblob \
+  --out target/l2-place-on
+```
+
+Inspect what it carries, and what each node would run under either mapping:
+
+```sh
+cargo run --release -p plowrt --no-default-features --features cpu \
+  --example l2_probe -- target/l2-place-on/model.pkt 8
+```
+
+A/B the two placements:
+
+```sh
+for place in 1 0; do
+  PLOW_CPU_L2_PLACE=$place cargo run --release -p plowrt \
+    --no-default-features --features cpu --example cpu_bench -- \
+    target/l2-place-on/model.pkt <checkpoint> \
+    --prompt-lens 128 --decode 8 --isa avx512 --threads 192
+done
+```
+
+## Host
+
+EPYC 9654 96-Core, dual socket, 192 physical / 384 logical cpus, 8 NUMA nodes
+(24 cores each), 2.2 TiB RAM. AVX-512 F/BW/VL/BF16/VNNI, no AMX.
+Model: Gemma-4 31B dense bf16, 60 layers, hidden 5376, 57.18 GiB of weights,
+`n_cu = 132`, 8 L2 domains, blocked map.

--- a/perf-data/cpu-worker-width/epyc9654-avx512/README.md
+++ b/perf-data/cpu-worker-width/epyc9654-avx512/README.md
@@ -1,0 +1,73 @@
+# Worker width vs packet executors — EPYC 9654, AVX-512
+
+The automatic CPU worker width ignored the packet's executor count, so a dense model on a
+wide host spawned far more workers than the packet could ever give work to. Capping the
+automatic width at `--n-cu` measured **8.3x faster decode** and **1.55x faster TTFT**.
+
+## The defect
+
+`cu_map` deals cus `0..n_cu` over the pool, so a worker with index past `n_cu` owns nothing
+— in every program, permanently. It is not idle-for-this-program, it is unusable for the
+whole model. Each run it still wakes on the control ring, finds an empty stream, returns,
+and then spins `--cpu-spin-us` (2000 µs default) before parking. A healthy decode step here
+is ~400 µs, so each surplus worker burns roughly five steps' worth of spin per gap, on the
+cores the working set needs.
+
+The old width rule never looked at `n_cu`: it picked physical cores for MoE and *logical*
+CPUs for a dense single-row decode. On this host that is 384 workers against a 144-cu
+packet — 240 of them unusable.
+
+## Measured
+
+Gemma-4 31B dense bf16, 57.18 GiB, `n_cu = 144`, `--prompt-lens 512 --decode 6`, AVX-512,
+means of 3 runs:
+
+| workers | TTFT | decode step | idle workers |
+| ---: | ---: | ---: | ---: |
+| 384 (all logical — the old automatic width) | 20499 ms | 3459 ms | 240 |
+| 192 (all physical) | 16235 ms | 1196 ms | 48 |
+| **144 (`n_cu` — the new automatic width)** | **14078 ms** | **415 ms** | **0** |
+
+The penalty tracks the idle count, not the thread count: 240 idle is 8.3x on decode, 48 idle
+is 2.9x, 0 is the baseline. Weight bandwidth over the same runs goes 52 → 164 GB/s.
+
+Confirmed after the fix, with the width left automatic (`--cpu-threads 0`): 144 workers
+selected, 13245 ms TTFT and 418 ms per step — i.e. it reproduces the explicit-144 arm.
+
+## The rule
+
+Auto width = min(model-preferred topology width, `n_cu`), floor 1.
+
+Two exemptions, both deliberate:
+
+* **An explicit `--cpu-threads` is honoured as given**, above `n_cu` included. The surplus is
+  the caller's to spend; the flag exists for hosts that disagree with the built-in rule.
+* **`--cpu-global-queue` is exempt.** Under the global queue every worker claims from the
+  shared per-(segment, domain) window rather than owning a static stream, so workers past
+  `n_cu` do useful work instead of idling. The cap would be a real loss there.
+
+## Relation to the per-program narrowing that was rejected earlier
+
+`exec::cpu::engine` already carries a note explaining that narrowing the pool *per program*
+measured worse — an idle worker polls on the SMT sibling of a busy core and that tax exceeded
+the gain. This cap is not that. A per-program narrowing leaves a worker idle for one program
+and busy for another, so there is a width tradeoff to lose; a worker past `n_cu` is idle for
+every program, so there is none. The two coexist: the width is still chosen per model, and
+then capped.
+
+## Host
+
+EPYC 9654 96-Core, dual socket, 192 physical / 384 logical cpus, 8 NUMA nodes, 2.2 TiB RAM.
+AVX-512 F/BW/VL/BF16/VNNI, no AMX.
+
+## Reproducing
+
+```sh
+for t in 0 192 144; do
+  cargo run --release -p plowrt --no-default-features --features cpu \
+    --example cpu_bench -- <bundle>/model.pkt <checkpoint> \
+    --prompt-lens 512 --decode 6 --isa avx512 --threads "$t"
+done
+```
+
+`--threads 0` is the automatic width; the `engine:` line reports what it chose.

--- a/runtime/cpu/dev/avx512/avx512.h
+++ b/runtime/cpu/dev/avx512/avx512.h
@@ -110,12 +110,16 @@ static inline __m512 v_tanh(__m512 x) {
     const __m512 e = v_expf(_mm512_mul_ps(two, x));
     return _mm512_sub_ps(one, _mm512_div_ps(two, _mm512_add_ps(one, e)));
 }
+/* 0.5*x*(1 + tanh(c)) == x * sigmoid(2c), so the constant carries the doubling. The tanh form
+ * cancels catastrophically once tanh(c) approaches -1: `1 + tanh` then keeps only the bits the
+ * subtraction inside v_tanh left behind, which in the far-negative tail is a few percent of the
+ * result. The sigmoid form is the same function evaluated without that cancellation, and one
+ * operation cheaper. */
 static inline __m512 v_gelu_tanh(__m512 x) {
     const __m512 c = _mm512_mul_ps(
-        _mm512_set1_ps(0.7978845608028654f),
+        _mm512_set1_ps(2.0f * 0.7978845608028654f),
         _mm512_fmadd_ps(_mm512_set1_ps(0.044715f), _mm512_mul_ps(_mm512_mul_ps(x, x), x), x));
-    return _mm512_mul_ps(_mm512_mul_ps(_mm512_set1_ps(0.5f), x),
-                         _mm512_add_ps(_mm512_set1_ps(1.0f), v_tanh(c)));
+    return _mm512_mul_ps(x, v_sigmoid(c));
 }
 /* act 0 = gelu_tanh, 1 = silu, 2 = situ pair form (caller handles); NaN otherwise like golden. */
 static inline __m512 v_act_gate(__m512 g, uint32_t act) {

--- a/runtime/cpu/dev/avx512/gemm_quant.c
+++ b/runtime/cpu/dev/avx512/gemm_quant.c
@@ -1,6 +1,5 @@
 #include "avx512.h"
 #include "../mxfp4_common.h"
-#include "golden/fp8.h"
 #include "golden/gptoss.h"
 
 static __m128i fp8_encode(__m512 x) {
@@ -20,23 +19,48 @@ static __m128i fp8_encode(__m512 x) {
     return _mm512_cvtepi32_epi8(_mm512_or_si512(code, sign));
 }
 
+/* Fused gate/up (t3 present): x = act(gate) * up, rounded to bf16 and stored, with |x| folded
+ * into the row max in the same pass. Golden maxes over the ROUNDED value, so the bf16 round
+ * point precedes the abs. A NaN lane contributes 0, matching golden's fmaxf, which returns its
+ * non-NaN operand; act >= 2 poisons every lane to NaN in both tiers. Tail lanes are dropped from
+ * the max explicitly rather than leaning on act(0) == 0. */
+static inline __m512 quant_fused_row(plow_bf16* x, const plow_bf16* gate, const plow_bf16* up,
+                                     uint32_t K, uint32_t act) {
+    __m512 amax = _mm512_setzero_ps();
+    for (uint32_t k = 0; k < K; k += 16) {
+        const __mmask16 mask = K - k >= 16 ? 0xffff : v_tail16(K - k);
+        const __m512 g = v_act_gate(v_load_bf16_mask(gate + k, mask), act);
+        const __m256bh b = _mm512_cvtneps_pbh(_mm512_mul_ps(g, v_load_bf16_mask(up + k, mask)));
+        _mm256_mask_storeu_epi16(x + k, mask, (__m256i)b);
+        const __m512 v = _mm512_abs_ps(_mm512_cvtpbh_ps(b));
+        amax = _mm512_max_ps(amax, _mm512_maskz_mov_ps(mask & _mm512_cmp_ps_mask(v, v, _CMP_ORD_Q), v));
+    }
+    return amax;
+}
+
 V_K(v_quant_fp8) {
-    if (PLOW_CPU_TEN(in, T, 3)) { g_quant_fp8(in, slice, nblk, T, ctx); return; }
+    (void)ctx;
     uint8_t* q = PLOW_CPU_TEN(in, T, 0);
-    const plow_bf16* x = PLOW_CPU_TEN(in, T, 1);
+    plow_bf16* x = PLOW_CPU_TEN(in, T, 1);
     float* scales = PLOW_CPU_TEN(in, T, 2);
+    const plow_bf16* gate = PLOW_CPU_TEN(in, T, 3);
+    const plow_bf16* up = PLOW_CPU_TEN(in, T, 4);
     const uint32_t K = in->i[1];
     uint32_t lo, hi;
     g_range(in->i[0], slice, nblk, &lo, &hi);
     for (uint32_t m = lo; m < hi; m++) {
         const size_t row = (size_t)m * K;
         __m512 amax = _mm512_setzero_ps();
-        for (uint32_t k = 0; k < K; k += 16) {
-            const __mmask16 mask = K - k >= 16 ? 0xffff : (1u << (K - k)) - 1;
-            const __m512i b = _mm512_cvtepu16_epi32(_mm256_maskz_loadu_epi16(mask, x + row + k));
-            __m512 v = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_and_si512(b, _mm512_set1_epi32(0x7fff)), 16));
-            v = _mm512_maskz_mov_ps(_mm512_cmp_ps_mask(v, v, _CMP_ORD_Q), v);
-            amax = _mm512_max_ps(amax, v);
+        if (gate) {
+            amax = quant_fused_row(x + row, gate + row, up + row, K, in->i[2]);
+        } else {
+            for (uint32_t k = 0; k < K; k += 16) {
+                const __mmask16 mask = K - k >= 16 ? 0xffff : (1u << (K - k)) - 1;
+                const __m512i b = _mm512_cvtepu16_epi32(_mm256_maskz_loadu_epi16(mask, x + row + k));
+                __m512 v = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_and_si512(b, _mm512_set1_epi32(0x7fff)), 16));
+                v = _mm512_maskz_mov_ps(_mm512_cmp_ps_mask(v, v, _CMP_ORD_Q), v);
+                amax = _mm512_max_ps(amax, v);
+            }
         }
         scales[m] = fmaxf(_mm512_reduce_max_ps(amax) * (1.0f / 448.0f), 1e-12f);
         const __m512 inv = _mm512_set1_ps(1.0f / scales[m]);

--- a/runtime/tests/cpu_dev_avx512_gemm_test.c
+++ b/runtime/tests/cpu_dev_avx512_gemm_test.c
@@ -179,6 +179,33 @@ static uint8_t fp8_oracle(float x) {
     return sign | (dl < dh || (dl == dh && !(lo & 1)) ? lo : hi);
 }
 
+/* v_gelu_tanh must keep the far-negative tail. Evaluating 0.5*x*(1 + tanh(c)) there cancels away
+ * the whole result -- the scalar tier's tanhf saturates to exactly -1 and flushes the output to
+ * zero -- so the kernel uses the identity x * sigmoid(2c). The reference is that identity in
+ * double, which is the one form that stays accurate here. */
+static int gelu_tail_check(void) {
+    enum { N = 64 };
+    plow_bf16 gate[N], up[N], out[N];
+    for (unsigned i = 0; i < N; i++) {
+        gate[i] = plow_f2bf(-4.0f - 5.0f * (float)i / (N - 1));
+        up[i] = plow_f2bf(1.0f);
+    }
+    PlowDevInst in = {0}; in.op = PLOW_DOP_GLU;
+    for (unsigned i = 0; i < 8; i++) in.t[i] = i < 3 ? i : PLOW_TENSOR_NONE;
+    in.i[0] = N; in.i[1] = 0;
+    void* T[] = {out, gate, up}; PlowCpuCtx ctx = {0};
+    plow_cpu_kernel(in.op)(&in, 0, 1, T, &ctx);
+    int bad = 0;
+    for (unsigned i = 0; i < N; i++) {
+        const double g = plow_bf2f(gate[i]);
+        const double c = 2.0 * 0.7978845608028654 * (g + 0.044715 * g * g * g);
+        const double want = g / (1.0 + exp(-c));
+        bad += fabs(plow_bf2f(out[i]) - want) > 0.02 * fabs(want);
+    }
+    if (bad) printf("FAIL gelu tail (%d)\n", bad);
+    return bad;
+}
+
 static int activation_quant_check(void) {
     int bad = 0;
     for (unsigned code = 0; code < 126; code++) {
@@ -248,6 +275,47 @@ static int activation_quant_check(void) {
                 : 0.5f * g * (1.0f + tanhf(0.7978845608028654f * (g + 0.044715f*g*g*g)));
             bad += fabsf(plow_bf2f(x[k]) - activated*u) > 0.005f * fabsf(activated*u) + 1e-6f;
             bad += q[k] != fp8_oracle(plow_bf2f(x[k]) * (1.0f / scales[k/17]));
+        }
+    }
+    /* The vectorized fused gate/up path against golden, over widths that exercise the masked
+     * tail and every slice split. The two tiers evaluate the activation differently, so the
+     * bound is against each row's own dynamic range -- what the fp8 scale encodes -- and not
+     * against bit patterns: deep in the gelu tail both tiers sit within noise of zero, while a
+     * masking, slicing or indexing regression moves a value by a sizable fraction of its row.
+     * The gate stride keeps every row spanning the whole range, so no row is all-tail. */
+    for (unsigned act = 0; act < 2; act++) {
+        const unsigned widths[] = {1, 15, 16, 17, 129, 1024};
+        for (unsigned shape = 0; shape < sizeof widths / sizeof widths[0]; shape++) {
+            const unsigned K = widths[shape], M = 5, n = M * K;
+            plow_bf16* gate = malloc(n*2), *up = malloc(n*2), *x = malloc(n*2), *xr = malloc(n*2);
+            uint8_t* q = malloc(n), *qr = malloc(n);
+            float sc[5], scr[5];
+            for (unsigned i = 0; i < n; i++) {
+                gate[i] = plow_f2bf(((int)((i * 37) % 97) - 48) / 12.0f);
+                up[i] = plow_f2bf(((int)((i * 11) % 53) - 26) / 9.0f);
+            }
+            PlowDevInst in = {0}; in.op = PLOW_DOP_QUANT_FP8;
+            for (unsigned i = 0; i < 8; i++) in.t[i] = i < 5 ? i : PLOW_TENSOR_NONE;
+            in.i[0] = M; in.i[1] = K; in.i[2] = act;
+            void* Tg[] = {qr, xr, scr, gate, up}, *Tv[] = {q, x, sc, gate, up};
+            PlowCpuCtx ctx = {0};
+            for (unsigned blocks = 1; blocks <= 7; blocks += 6)
+                for (unsigned slice = 0; slice < blocks; slice++) {
+                    gold[in.op](&in, slice, blocks, Tg, &ctx);
+                    plow_cpu_kernel(in.op)(&in, slice, blocks, Tv, &ctx);
+                }
+            for (unsigned m = 0; m < M; m++) {
+                float hi = 0;
+                for (unsigned k = 0; k < K; k++) hi = fmaxf(hi, fabsf(plow_bf2f(xr[m*K+k])));
+                bad += fabsf(sc[m] - scr[m]) > 0.01f * scr[m];
+                for (unsigned k = 0; k < K; k++) {
+                    const unsigned i = m * K + k;
+                    bad += fabsf(plow_bf2f(x[i]) - plow_bf2f(xr[i])) > 0.01f * hi;
+                    /* fp8 codes are only comparable where the value carries signal. */
+                    bad += fabsf(plow_bf2f(xr[i])) > 0.05f * hi && abs((int)q[i] - (int)qr[i]) > 1;
+                }
+            }
+            free(gate); free(up); free(x); free(xr); free(q); free(qr);
         }
     }
     if (bad) printf("FAIL activation FP8 quantization (%d)\n", bad);
@@ -340,7 +408,7 @@ int main(int argc, char** argv) {
     if (plow_cpu_init(PLOW_CPU_ISA_AVX512) < PLOW_CPU_ISA_AVX512) return 77;
     const uint16_t ops[] = {PLOW_DOP_GEMM, PLOW_DOP_GEMM_SMALL, PLOW_DOP_GEMM_MED,
         PLOW_DOP_GEMM_WIDE, PLOW_DOP_GEMM_C5, PLOW_DOP_GEMM_NORM, PLOW_DOP_GEMM_GLU};
-    int bad = splitk_check() + activation_quant_check() + moe_fp8_check();
+    int bad = splitk_check() + activation_quant_check() + moe_fp8_check() + gelu_tail_check();
     for (size_t i = 0; i < sizeof ops / sizeof ops[0]; i++) {
         bad += check(ops[i], 7, 19, 1, 0);
         bad += check(ops[i], 17, 259, 33, 0);


### PR DESCRIPTION
Two pieces of CPU-backend work: an AVX-512 kernel win that is real, and a NUMA placement idea that measured worse and therefore ships off. Both are on top of `main` (PR #21 is merged; this adds seven commits).

## 1. AVX-512: fused gate/up FP8 quantization (`fde0ddab`)

`QUANT_FP8`'s fused gate/up form — the W8A8 activation quantization ahead of a down projection — bailed to the scalar reference on the vector tier. It now computes the activation, the bf16 store, and the row maximum in one pass.

| shape | scalar | AVX-512 | |
| --- | ---: | ---: | ---: |
| M=1, K=8192 (decode row) | 0.064 ms | 0.007 ms | **9.7x** |
| M=64, K=8192 | 4.136 ms | 0.420 ms | **9.8x** |
| M=256, K=4096 | 12.632 ms | 0.944 ms | **13.4x** |

Single-threaded on an EPYC 9654. Op coverage is otherwise already complete — only NOP, ZERO_F32, MoE align, and the deliberately-exact Gemma router score remain scalar.

### A real defect this exposed

`v_gelu_tanh` evaluated `0.5*x*(1 + tanh(c))` over `v_tanh`'s `1 - 2/(1 + exp(2c))` form, so once `tanh(c)` approached −1 the `1 + tanh` kept only the bits the subtraction left behind — often zero. It now evaluates the algebraically identical `x * sigmoid(2c)`: no cancellation, one operation cheaper, and **every AVX-512 GLU consumer gains it**, not just the new path.

The tiers now disagree in the far-negative gelu tail, where the *scalar* tier is the inaccurate one (`tanhf` saturates to exactly −1 and flushes to zero). Magnitudes there are far under one fp8 code of the row scale.

## 2. NUMA executor placement: measured, and turned off (`0c051cd2`, `add358ae`, `37dfdd5d`)

Placement assigned `cu → node` as a blind `cu % nodes`, never reading the L2 locality domains the emitter tags onto every stream entry. Making it follow those domains looked obviously right. It is not.

**Measured 1.5x slower**, interleaved A/B on a real L2-placed blob (H100-mapped Gemma-4-31B, 57 GiB, `n_cu=132`), 8 NUMA nodes, 192 threads:

| | domain placement | `cu % nodes` | |
| --- | ---: | ---: | ---: |
| TTFT (mean of 3) | 11339 ms | 7230 ms | **1.57x slower** |
| decode step (mean of 3) | 1884 ms | 1258 ms | **1.50x slower** |

Repeats spanned 1.6% and 7.2% within arms. At 2 nodes it was 1.14–1.15x slower. Never faster, at any node count.

**Why, and it is not an artifact of one blob.** An L2 domain says which slices share a *GPU* cache. It says nothing about which weights they touch, and CPU model tensors are interleaved across every node regardless — so grouping by domain creates no locality here. It only spends the round-robin's balance, because nothing makes domains equal in *cost*: under the blocked map the low-numbered cus carry every narrowly-sliced op, so one node inherits a third of the packet. Work per node runs **3.0–4.1x** max/min placed against **1.04–1.12x** round-robin.

That also falsified a balance claim the first of these commits made, which is fixed here rather than left standing.

The mechanism is kept rather than reverted because it costs nothing when off — not because a win is expected. Under the AMD round-robin map the plan reduces to `cu % nodes` exactly when the domain count equals the node count, so an 8-XCD blob on an 8-node host is the identical mapping; and a gfx950 blob does not load on the CPU backend at all.

### The obvious rescue was tried, and fails too

`n_cu=132` does not divide by the 18 SMs per partition, leaving domain 7 with 6 cus. Recompiling at `--n-cu 144` fixes exactly that: emitter prefill skew drops from 66.8-75.5% to **0.3%**, and the placed peak lands within **0.14%** of round-robin's.

Placement is still **1.24x slower** on prefill with that objection removed (18611 ms vs 15038 ms TTFT, means of 3 interleaved runs). Decode became neutral, locating the earlier 1.50x decode loss in the 6-cu node rather than the idea.

Per-node work balance is not per-op concurrency. `GEMM` is 291 instructions averaging **89.6 of 144 slices**, and a contiguous domain map confines a k-slice op to `ceil(k/18)` nodes -- a 90-slice GEMM runs on 5 of 8 nodes while round-robin spreads it over all 8. Summed per node those even out (the 0.14%) while every barrier still waits on a narrower machine. No domain-to-node assignment fixes it: the narrowing is in the map's contiguity in cu index. And there is no locality to win it back, since tensors are `mbind`-interleaved so a weight read is ~1/8 local wherever the thread sits.

Full numbers, mechanism and repro: `perf-data/cpu-numa-placement/epyc9654-avx512/README.md`.

### Design point that survives

The packet stays topology-free. `plowc` is unchanged and emits no host topology: a blob is no more built for a node count than for a core count. The packet fixes how work is *divided* (`n_cu` virtual executors, each kernel taking the slice-th of nblk shares); a pool of any width covers it, so one blob serves any core count. Compile once at a width dividing the largest core count you intend to serve — the emitter caps `n_cu` at 256.

## Review fixes folded in (`37dfdd5d`)

- **Guard could approve an imbalanced execution.** The balance test summed work across programs, but programs are *alternatives* — a prefill bucket or the decode program per dispatch — so their sum is a load nothing experiences. Two programs at 200/2 and 2/200 across a node pair total 202/202 and were waved through. The test now applies per program.
- **Probe reported a candidate as a decision.** `l2_probe` printed `PLACED` on the blob the runtime refuses. It now prints `CANDIDATE` and `ACCEPTED` separately and calls the engine's own `cu_domains`/`cu_work`/`node_plan` rather than a copy — drift is structurally impossible, not just corrected once.

## Verification

- **270** plowrt cpu tests (19 new) and all **10** C `cpu_dev` targets pass on an EPYC 9654 with AVX-512 F/BW/VL/BF16/VNNI.
- ASan/UBSan clean on the vector and GEMM suites.
- New AVX-512 tests: a differential pinning the fused path against golden across widths 1–1024 and every slice split, plus a gelu tail check that **fails 59 of 64 points on the old formulation**.
- New placement tests: the no-plan path is pinned to the exact previous mapping so the plan is purely additive; an end-to-end check that a plan changes *where* a cu runs and not *what* runs; and the reviewer's imbalance shape as a regression case.
- `live_numa_policy` passes. rustfmt and clippy clean on all changed files.

## 3. CPU worker pool: bindings review, and a live defect (`dc43906a`)

Reviewing the Rust↔C bindings and the worker lifecycle turned up one real bug, in the **automatic worker width**. `cu_map` deals cus `0..n_cu` over the pool, so a worker past `n_cu` owns nothing — in every program, permanently. It still wakes each run, finds an empty stream, and spins `--cpu-spin-us` (2 ms) before parking, on the cores the working set needs; a healthy decode step here is ~400 µs.

The width rule never consulted `n_cu` — physical cores for MoE, *logical* CPUs for dense decode. On this 8-node EPYC 9654 that is 384 workers against a 144-cu packet, 240 unusable. Gemma-4-31B dense, means of 3:

| workers | TTFT | decode step | idle |
| ---: | ---: | ---: | ---: |
| 384 (old automatic width) | 20499 ms | 3459 ms | 240 |
| 192 (all physical) | 16235 ms | 1196 ms | 48 |
| **144 (`n_cu`, new)** | **14078 ms** | **415 ms** | **0** |

**8.3x on decode, 1.55x on TTFT**; weight bandwidth 52 → 164 GB/s. The penalty tracks the *idle* count, not the thread count. Explicit `--cpu-threads` is still honoured as given, and `--cpu-global-queue` is exempt (there every worker claims from the shared window).

This is *not* the per-program narrowing the engine already documents as measured worse — that leaves a worker idle for one program and busy for another; these are idle for every program, so there is no tradeoff to lose.

**Persistence is now actually tested.** The old test asserted `p.threads()`, which only counts join handles and cannot change. The new one records `ThreadId`s from inside the kernels and asserts the same set serves all 200 runs, at every width.

**No binding bugs found**, which is worth stating: the ABI is locked by compiler probes over sizes, every field offset and the tier constants; the nullable kernel pointer uses `Option<fn>`; `plow_cpu_init` is idempotent, mutex-serialized and ordered before spawn so AMX `XTILEDATA` permission is inherited; `thread_init` runs lazily *on* the worker for per-thread tile config; every C scratch consumer guards `scratch_bytes` and falls back to golden; `CpuEngine` field order drops the pool before the model, with a comment saying why; and `wait_until` parks with a timeout, so a lost wakeup costs latency, never a hang.

Numbers and repro: `perf-data/cpu-worker-width/epyc9654-avx512/README.md`.

## Docs (`3010ea95`)

Compiling for CPU was undocumented — I had to reverse-engineer it from a log in `perf-data`. Nothing said the interpreter-object step is skipped, that `plowc` still needs a device target, or that a gfx942/gfx950 packet is **rejected at load** (which surfaces as a corrupt-blob-looking error, not an unsupported-target one). `docs/flags-reference.md` also called itself the full flag reference while documenting zero CPU flags.

- **README**: a CPU-only section — the three steps minus step 2, with the NVIDIA `--gpu` requirement called out.
- **`docs/runtime/cpu.md`**: a "Compiling a bundle" section and a full `## Flags` table.
- **`docs/flags-reference.md`**: the same table under its own conventions.

The point documented loudest: `--n-cu` is the packet's *virtual* executor count, not a thread count — the pool maps any number of threads onto it, so one bundle serves any core count. Both off-by-default A/B knobs state in the table that they are off because they measured slower, with the numbers.

Verified rather than written from memory: every flag name, env twin and default matches `plowrt serve --help`; the README's compile line was run end to end (emits `n_cu=96`, and the blob loads and generates at 192 threads — the worked example of the two differing); every link and the `#flags` anchor resolve.

## Not done

- The AMD round-robin domain map is unmeasured — not reachable on this host (a gfx950 blob does not load on the CPU backend). It spreads each op across nodes rather than narrowing it, so it is the shape most likely to come out *neutral*, not the shape most likely to win.
- The global-queue path (`PLOW_CPU_GQ=1`) is untouched and remains off by default.
- Pre-existing and untouched: repo-wide rustfmt drift (`cpu_interp.rs`, examples, `serve/`), clippy warnings elsewhere in plowrt, and a clippy error in `examples/cpu_probe.rs`.
- Separate follow-up not taken: `gemm_quant.c:121`, `v_moe_expert_glu_gemma_fp8` still calls scalar `g_gelu_tanh` per element inside a vector kernel.

Draft because the placement half is a deliberate negative result — worth a second opinion on keeping the mechanism at all versus reverting it. The AVX-512 half stands on its own and is the reason to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfQdJ6P1pCDUVUtWfjXDC2
