### PR TITLE
Queue-driven CPU prefill offload: mechanism, refusals, and a conditional (not blanket) verdict

### DIFF
--- a/crates/plow-asset/src/kv_contract.rs
+++ b/crates/plow-asset/src/kv_contract.rs
@@ -1,0 +1,126 @@
+//! The KV-geometry contract binding a device packet to its CPU twin.
+//!
+//! A prompt head prefilled on the CPU reaches the device as a **byte copy of a
+//! row range** out of each per-slot KV cache. That is sound only if both packets
+//! lay a sequence slot out identically, and nothing else in the bundle says so:
+//! the two are separate emits, the twin is compiled for a different target, and
+//! a mismatch produces no fault and no missing weight — just a slot whose rows
+//! `[0, n)` hold another geometry's bytes, which reads as fluent wrong output.
+//! So the pair carries a digest and is refused when they disagree.
+//!
+//! **Per-slot bytes is the right invariant, and it has to be.** The caches are
+//! head-major — a `(kv, head)` slot holds `max_seq_len × head_dim × elem` bytes
+//! and a token's row sits inside it — so a twin compiled at a different
+//! `--max-ctx` keeps the row stride and moves every head-slot boundary. Rows
+//! `[0, n)` of head 1 then land at the wrong offset while head 0 still looks
+//! right. Comparing the per-slot extent catches that; comparing a row stride
+//! would not.
+
+use sha2::{Digest, Sha256};
+
+/// One append-only KV cache tensor and the bytes one sequence slot occupies.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CacheTensor {
+    pub name: String,
+    pub per_slot_bytes: u64,
+}
+
+/// Is `name` an append-only per-slot KV cache — the set a row range may be
+/// copied out of?
+///
+/// Two exclusions from the `kv.` namespace, both load-bearing and both already
+/// stated at their other call sites in `exec::amd`:
+///
+/// * `kv.blkres` — K3's AttnRes snapshot ring, `[t][nb_cap][hidden]`, sized at
+///   the widest prefill bucket rather than the slot count. It has no sequence
+///   axis, so it has no per-slot stride to agree about.
+/// * the KDA carried state (`kv.{l}.state`, `kv.{l}.conv_state.*`) — read
+///   before it is written, so a row range does not reconstruct it. A head that
+///   copied one would hand the device a recurrence that skipped its own update.
+///
+/// Substring rather than suffix, for the reason `is_carried_state` gives: the
+/// three `conv_state.{q,k,v}` tensors are one idea, and a future
+/// `kv.{l}.state.v` must not slip past a match written against today's
+/// spellings.
+pub fn is_cache_tensor(name: &str) -> bool {
+    name.starts_with("kv.") && !name.contains("blkres") && !name.contains("state")
+}
+
+/// Digest over the per-slot KV geometry. Equal digests mean a row range copied
+/// out of one packet's slot lands correctly in the other's.
+pub fn digest(tensors: &[CacheTensor]) -> String {
+    let mut h = Sha256::new();
+    h.update(b"plow-kv-contract-v1");
+    h.update((tensors.len() as u64).to_le_bytes());
+    for t in tensors {
+        h.update((t.name.len() as u64).to_le_bytes());
+        h.update(t.name.as_bytes());
+        h.update(t.per_slot_bytes.to_le_bytes());
+    }
+    format!("{:x}", h.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ct(name: &str, per_slot_bytes: u64) -> CacheTensor {
+        CacheTensor {
+            name: name.to_string(),
+            per_slot_bytes,
+        }
+    }
+
+    #[test]
+    fn the_cache_set_is_the_append_only_kv_tensors() {
+        assert!(is_cache_tensor("kv.0.k"));
+        assert!(is_cache_tensor("kv.7.ckv"));
+        assert!(is_cache_tensor("kv.7.krot"));
+        assert!(is_cache_tensor("kv.3.k_scale"));
+        // Not per-sequence, or not reconstructible from a row range.
+        assert!(!is_cache_tensor("kv.blkres"));
+        assert!(!is_cache_tensor("kv.4.state"));
+        assert!(!is_cache_tensor("kv.4.conv_state.q"));
+        assert!(!is_cache_tensor("kv.4.state.v"));
+        // Not the KV namespace at all.
+        assert!(!is_cache_tensor("model.layers.0.mlp.gate"));
+        assert!(!is_cache_tensor("in.kvlen"));
+    }
+
+    #[test]
+    fn the_digest_is_over_a_sorted_set_not_a_declaration_order() {
+        // Callers sort; this asserts the digest actually distinguishes the two
+        // orders, so an unsorted caller is a bug the pair check will catch
+        // rather than one it will silently tolerate.
+        let sorted = vec![ct("kv.0.k", 32), ct("kv.1.k", 64)];
+        let unsorted = vec![ct("kv.1.k", 64), ct("kv.0.k", 32)];
+        assert_ne!(digest(&sorted), digest(&unsorted));
+    }
+
+    #[test]
+    fn a_different_slot_extent_is_a_different_contract() {
+        // The twin compiled at another `--max-ctx`: same tensors, same row
+        // stride, every head-slot boundary moved.
+        let dev = vec![ct("kv.0.k", 8192)];
+        let twin = vec![ct("kv.0.k", 4096)];
+        assert_ne!(digest(&dev), digest(&twin));
+    }
+
+    #[test]
+    fn a_missing_cache_is_a_different_contract() {
+        // The GLM-5.3 hazard: a twin that writes the latent but not the DSA
+        // pooled indexer cache would leave the indexer scoring the head's rows
+        // against uninitialised keys.
+        let dev = vec![ct("kv.0.ckv", 4096), ct("kv.0.idx_pool", 512)];
+        let twin = vec![ct("kv.0.ckv", 4096)];
+        assert_ne!(digest(&dev), digest(&twin));
+    }
+
+    #[test]
+    fn names_are_length_prefixed_so_concatenation_cannot_collide() {
+        let a = vec![ct("kv.0.ka", 1), ct("kv.0.b", 1)];
+        let b = vec![ct("kv.0.k", 1), ct("kv.0.ab", 1)];
+        assert_ne!(digest(&a), digest(&b));
+    }
+
+}

--- a/crates/plow-asset/src/lib.rs
+++ b/crates/plow-asset/src/lib.rs
@@ -680,6 +680,7 @@ pub mod aux_program;
 pub mod program;
 pub mod splitk;
 
+pub mod kv_contract;
 pub mod live_kv;
 pub mod mixed_step;
 

--- a/crates/plowrt/examples/head_probe.rs
+++ b/crates/plowrt/examples/head_probe.rs
@@ -1,0 +1,53 @@
+//! Ask whether a bundle can serve CPU prefill heads, and say why not.
+//!
+//! `cargo run --release --features cpu --example head_probe -- <twin.pkt> <ckpt> [cores]`
+//!
+//! The packet-level refusals run before the checkpoint is touched, so a model
+//! whose caches are not addressable as row ranges answers in milliseconds
+//! rather than after a 22 GiB load.
+
+#[cfg(feature = "cpu")]
+fn main() {
+    use plowrt::exec::cpu::engine::CpuEngineOpts;
+    use plowrt::exec::cpu::ffi::Isa;
+    use plowrt::serve::head::{host_supports_heads, HeadPool};
+    use std::path::PathBuf;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let mut args = std::env::args().skip(1);
+    let twin: PathBuf = args.next().expect("usage: head_probe <twin.pkt> <ckpt>").into();
+    let ckpt: PathBuf = args.next().expect("usage: head_probe <twin.pkt> <ckpt>").into();
+    let n_cores: usize = args.next().map(|s| s.parse().unwrap()).unwrap_or(8);
+    let cores: Vec<u32> = (0..n_cores as u32).collect();
+
+    match host_supports_heads(Isa::Avx512, cores.len()) {
+        Ok(()) => println!("host gate: OK ({} cores reserved)", cores.len()),
+        Err(why) => {
+            println!("host gate: REFUSED — {why}");
+            return;
+        }
+    }
+
+    let opts = CpuEngineOpts {
+        threads: n_cores,
+        ..Default::default()
+    };
+    match HeadPool::load(&twin, &ckpt, &opts, &cores) {
+        Ok(pool) => println!(
+            "twin ACCEPTED: slots={} kv_contract={}",
+            pool.slots(),
+            pool.kv_contract()
+        ),
+        Err(e) => println!("twin REFUSED — {e}"),
+    }
+}
+
+#[cfg(not(feature = "cpu"))]
+fn main() {
+    eprintln!("build with --features cpu");
+}

--- a/crates/plowrt/src/config.rs
+++ b/crates/plowrt/src/config.rs
@@ -333,6 +333,16 @@ pub struct HetRuntimeConfig {
         global = true
     )]
     pub reserve_cores: u32,
+
+    /// The CPU-executable packet a prefill head runs. Defaults to
+    /// `<assets>/cpu-twin/model.pkt` when that exists.
+    ///
+    /// A twin is not a new artifact class: it is another VARIANT of the same
+    /// model — same `--max-ctx`, a target the CPU interpreter accepts — so a
+    /// distribution selects and pulls it the way it selects any variant, and
+    /// this names the bundle that selection materialised.
+    #[arg(long = "het-twin", env = "PLOW_HET_TWIN", global = true)]
+    pub twin: Option<String>,
 }
 
 /// Kernel-tier ceiling for the CPU engine (`--cpu-isa`).

--- a/crates/plowrt/src/config.rs
+++ b/crates/plowrt/src/config.rs
@@ -237,6 +237,12 @@ pub struct RuntimeConfig {
 
     #[command(flatten)]
     pub apple: AppleRuntimeConfig,
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Heterogeneous prefill (feature = "cpu")
+    // ──────────────────────────────────────────────────────────────────────────
+    #[command(flatten)]
+    pub het: HetRuntimeConfig,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -297,6 +303,36 @@ pub struct AppleRuntimeConfig {
     /// Enable legacy CoreML output-range diagnostics when present.
     #[arg(long = "ane-out-range", env = "PLOW_OUT_RANGE", global = true)]
     pub out_range: Option<String>,
+}
+
+/// Core reservation for the CPU prefill-head pool.
+///
+/// OFF unless one of these is set, and off means the process places no thread it
+/// did not place before. The head pool spends CPU the serving path is not using,
+/// so the reservation has to be stated rather than guessed: an under-reservation
+/// costs GPU tick latency, which is the one thing this must not do.
+#[derive(Args, Debug, Clone)]
+#[command(next_help_heading = "Heterogeneous prefill")]
+pub struct HetRuntimeConfig {
+    /// Logical CPUs the prefill-head pool may use (`4-7,12`). The serving path
+    /// takes the rest. Overrides `--het-reserve-cores`.
+    #[arg(long = "het-cores", env = "PLOW_HET_CORES", global = true)]
+    pub cores: Option<String>,
+
+    /// Physical cores reserved for the serving path — engine threads, H2D
+    /// staging, interrupt/completion work — with the head pool taking what is
+    /// left. 0 leaves heterogeneous prefill off entirely.
+    ///
+    /// WHOLE cores including their SMT siblings: a sibling running a head shares
+    /// the core's execution resources with the engine thread, so reserving one
+    /// thread of a core and handing the other to the head pool reserves nothing.
+    #[arg(
+        long = "het-reserve-cores",
+        env = "PLOW_HET_RESERVE_CORES",
+        default_value_t = 0,
+        global = true
+    )]
+    pub reserve_cores: u32,
 }
 
 /// Kernel-tier ceiling for the CPU engine (`--cpu-isa`).

--- a/crates/plowrt/src/exec/affinity.rs
+++ b/crates/plowrt/src/exec/affinity.rs
@@ -1,0 +1,256 @@
+//! Thread placement for the two pools that must not contend: the GPU tick's
+//! engine thread and the CPU prefill-head pool.
+//!
+//! The head pool exists only to spend CPU the serving path is not using, so it
+//! must not be able to take any. Two mechanisms, and they bound different
+//! things:
+//!
+//! * **Affinity** keeps the pools on disjoint physical cores. Whole cores, not
+//!   logical cpus — an SMT sibling running a head shares the core's execution
+//!   resources with the engine thread, so reserving one thread of a core and
+//!   handing the other to the head pool reserves nothing.
+//! * **`SCHED_IDLE`** means a head thread cannot preempt a normally-scheduled
+//!   serving thread even where the masks do overlap. Its precondition is that
+//!   the head pool shares no lock with the serving path: an idle-priority
+//!   thread holding one inverts priority. It shares no engine state by
+//!   construction; the allocator is the real hazard, which is why head buffers
+//!   are allocated when the pool arms rather than inside a head.
+//!
+//! Neither bounds MEMORY BANDWIDTH. An idle-priority thread that is running
+//! still saturates the memory controllers, and the serving path's pinned-staging
+//! fills and H2D DMA reads slow down accordingly. That is bounded by the WIDTH
+//! of the head pool, which is why [`CorePlan::head`] is a budget and not
+//! "whatever is left over".
+
+use super::cpu::topology::Core;
+
+/// Which logical cpus each pool may run on.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CorePlan {
+    /// The serving path: engine threads, H2D staging, the async runtime.
+    pub serving: Vec<u32>,
+    /// The prefill-head pool. Empty means "no head may run here".
+    pub head: Vec<u32>,
+}
+
+impl CorePlan {
+    pub fn is_empty(&self) -> bool {
+        self.head.is_empty()
+    }
+}
+
+/// Split the machine's physical cores between the serving path and the head
+/// pool.
+///
+/// `reserve` whole cores go to serving, taken from the low end; the head pool
+/// gets the rest. An `explicit` cpu list overrides the split entirely — that is
+/// `--het-cores`, for an operator who knows their box better than this does —
+/// and is intersected with the cores actually present so a typo cannot pin a
+/// thread to a cpu that does not exist.
+///
+/// A `reserve` at or past the core count yields an empty head pool rather than
+/// an error. "There is no room for a head on this box" is a configuration, not
+/// a failure: the caller declines to arm and serves exactly as before.
+pub fn plan_cores(cores: &[Core], explicit: Option<&[u32]>, reserve: usize) -> CorePlan {
+    let all: Vec<u32> = cores.iter().flat_map(|c| c.siblings.iter().copied()).collect();
+    if let Some(want) = explicit {
+        let head: Vec<u32> = all.iter().copied().filter(|c| want.contains(c)).collect();
+        let serving: Vec<u32> = all.iter().copied().filter(|c| !head.contains(c)).collect();
+        return CorePlan { serving, head };
+    }
+    let split = reserve.min(cores.len());
+    CorePlan {
+        serving: cores[..split]
+            .iter()
+            .flat_map(|c| c.siblings.iter().copied())
+            .collect(),
+        head: cores[split..]
+            .iter()
+            .flat_map(|c| c.siblings.iter().copied())
+            .collect(),
+    }
+}
+
+/// The process-wide plan, resolved once from `--het-cores` /
+/// `--het-reserve-cores` against the live topology.
+///
+/// Empty (both pools) when neither knob is set: heterogeneous prefill is off and
+/// no thread is placed that was not placed before.
+pub fn plan() -> &'static CorePlan {
+    static PLAN: std::sync::OnceLock<CorePlan> = std::sync::OnceLock::new();
+    PLAN.get_or_init(|| {
+        let cfg = &crate::config::RuntimeConfig::get().het;
+        let explicit = cfg
+            .cores
+            .as_deref()
+            .map(super::cpu::topology::parse_cpulist);
+        if explicit.is_none() && cfg.reserve_cores == 0 {
+            return CorePlan::default();
+        }
+        let topo = super::cpu::topology::Topology::detect();
+        let plan = plan_cores(
+            &topo.cores,
+            explicit.as_deref(),
+            cfg.reserve_cores as usize,
+        );
+        tracing::info!(
+            serving = plan.serving.len(),
+            head = plan.head.len(),
+            cores = topo.cores.len(),
+            "heterogeneous prefill core plan"
+        );
+        plan
+    })
+}
+
+#[cfg(target_os = "linux")]
+mod sys {
+    /// Pin the calling thread to `cpus`. Returns false and warns on failure —
+    /// a box that refuses the mask should serve, not abort.
+    pub fn pin(cpus: &[u32]) -> bool {
+        if cpus.is_empty() {
+            return false;
+        }
+        // SAFETY: cpu_set_t is POD; sched_setaffinity acts on the calling thread.
+        unsafe {
+            let mut set: libc::cpu_set_t = std::mem::zeroed();
+            for &cpu in cpus {
+                if cpu as usize >= libc::CPU_SETSIZE as usize {
+                    tracing::warn!(cpu, "CPU id exceeds affinity mask capacity");
+                    continue;
+                }
+                libc::CPU_SET(cpu as usize, &mut set);
+            }
+            if libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set) != 0 {
+                tracing::warn!(
+                    ?cpus,
+                    error = %std::io::Error::last_os_error(),
+                    "CPU affinity failed"
+                );
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Put the calling thread on `SCHED_IDLE`, so it runs only when nothing
+    /// else wants the cpu.
+    pub fn set_idle_priority() -> bool {
+        // SAFETY: sched_param is POD; SCHED_IDLE takes priority 0 and the call
+        // acts on the calling thread.
+        unsafe {
+            let param = libc::sched_param { sched_priority: 0 };
+            if libc::sched_setscheduler(0, libc::SCHED_IDLE, &param) != 0 {
+                tracing::warn!(
+                    error = %std::io::Error::last_os_error(),
+                    "SCHED_IDLE failed; head threads can preempt the serving path"
+                );
+                return false;
+            }
+        }
+        true
+    }
+
+    /// The cpus this process is actually allowed to use, honouring cpusets and
+    /// `taskset`. Empty when the file is unreadable.
+    pub fn allowed_cpus() -> Vec<u32> {
+        std::fs::read_to_string("/proc/self/status")
+            .ok()
+            .and_then(|s| {
+                s.lines()
+                    .find_map(|l| l.strip_prefix("Cpus_allowed_list:"))
+                    .map(crate::exec::cpu::topology::parse_cpulist)
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod sys {
+    pub fn pin(_cpus: &[u32]) -> bool {
+        false
+    }
+    pub fn set_idle_priority() -> bool {
+        false
+    }
+    pub fn allowed_cpus() -> Vec<u32> {
+        Vec::new()
+    }
+}
+
+pub use sys::{allowed_cpus, pin, set_idle_priority};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn core(cpu: u32, node: u32, siblings: &[u32]) -> Core {
+        Core {
+            cpu,
+            node,
+            siblings: siblings.to_vec(),
+        }
+    }
+
+    /// Two nodes, four physical cores each with one SMT sibling — the EPYC
+    /// numbering where sibling(i) = i + n_cores.
+    fn smt_box() -> Vec<Core> {
+        (0..4)
+            .map(|i| core(i, i / 2, &[i, i + 4]))
+            .collect()
+    }
+
+    #[test]
+    fn a_reservation_takes_whole_cores_with_their_siblings() {
+        let plan = plan_cores(&smt_box(), None, 2);
+        // Cores 0 and 1 reserved: both threads of each, not just the low one.
+        assert_eq!(plan.serving, vec![0, 4, 1, 5]);
+        assert_eq!(plan.head, vec![2, 6, 3, 7]);
+    }
+
+    #[test]
+    fn the_pools_never_share_a_logical_cpu() {
+        for reserve in 0..=6 {
+            let plan = plan_cores(&smt_box(), None, reserve);
+            assert!(
+                !plan.serving.iter().any(|c| plan.head.contains(c)),
+                "overlap at reserve {reserve}"
+            );
+        }
+    }
+
+    #[test]
+    fn reserving_the_whole_box_leaves_no_head_pool() {
+        // Not an error: the caller declines to arm and serves as before.
+        let plan = plan_cores(&smt_box(), None, 4);
+        assert!(plan.is_empty());
+        assert_eq!(plan.serving.len(), 8);
+        // Past the core count is the same answer, not a panic.
+        assert!(plan_cores(&smt_box(), None, 99).is_empty());
+    }
+
+    #[test]
+    fn an_explicit_list_overrides_the_split() {
+        let plan = plan_cores(&smt_box(), Some(&[6, 7]), 2);
+        assert_eq!(plan.head, vec![6, 7]);
+        assert!(!plan.serving.contains(&6));
+        assert_eq!(plan.serving.len(), 6);
+    }
+
+    #[test]
+    fn an_explicit_list_cannot_name_a_cpu_the_box_does_not_have() {
+        let plan = plan_cores(&smt_box(), Some(&[6, 999]), 2);
+        assert_eq!(plan.head, vec![6]);
+    }
+
+    #[test]
+    fn no_reservation_is_a_plan_that_places_nothing() {
+        // The off state has to be an EMPTY serving set too: a caller that pins
+        // to `serving` must find nothing to pin to, not the whole box.
+        let plan = plan_cores(&smt_box(), None, 0);
+        assert!(plan.serving.is_empty());
+        assert_eq!(plan.head.len(), 8);
+        assert!(CorePlan::default().serving.is_empty());
+        assert!(CorePlan::default().is_empty());
+    }
+}

--- a/crates/plowrt/src/exec/amd.rs
+++ b/crates/plowrt/src/exec/amd.rs
@@ -13832,6 +13832,58 @@ impl AmdEngine {
     /// the base before returning. A stale rebase would put ALL sequences'
     /// decode KV inside one slot's block — hence the invariant is enforced in
     /// [`AmdEngine::decode_step_batched`] rather than left to callers.
+    /// Write a CPU prefill head's KV rows into this engine's caches.
+    ///
+    /// `plan` addresses the device side by tensor handle and byte offset;
+    /// `src` yields the matching bytes out of the head engine's host tensors.
+    /// The two agree because the packets' KV contracts were checked equal at
+    /// load, and that check is exactly what makes this a byte copy rather than
+    /// a translation.
+    ///
+    /// One upload per span, not a pinned-staging batch. The head engine's
+    /// tensors are ordinary host allocations rather than agent-visible memory,
+    /// so `memcpy_htod_pinned_batch` would need them staged into a pinned slab
+    /// first. That is worth doing once the transfer is measured and not before:
+    /// this runs while the request is still waiting for a slot, off the
+    /// per-token path.
+    pub fn write_kv_rows<'a>(
+        &self,
+        plan: &[crate::exec::kv_handoff::CopySpan],
+        src: impl Fn(&crate::exec::kv_handoff::CopySpan) -> Result<&'a [u8]>,
+    ) -> Result<u64> {
+        let mut moved = 0u64;
+        for span in plan {
+            let dst = self.devp.get(span.handle).ok_or_else(|| {
+                RuntimeError::Device(format!(
+                    "head handoff names tensor {}, past this packet's {}",
+                    span.handle,
+                    self.devp.len()
+                ))
+            })?;
+            let end = span.dst_off.checked_add(span.bytes).ok_or_else(|| {
+                RuntimeError::Device("head handoff span overflows".into())
+            })?;
+            if end > dst.len {
+                return Err(RuntimeError::Device(format!(
+                    "head handoff writes {}+{} of `{}`, which holds {} bytes",
+                    span.dst_off, span.bytes, self.tensor_names[span.handle], dst.len
+                )));
+            }
+            let bytes = src(span)?;
+            if bytes.len() as u64 != span.bytes {
+                return Err(RuntimeError::Device(format!(
+                    "head handoff source for `{}` is {} bytes, plan says {}",
+                    self.tensor_names[span.handle],
+                    bytes.len(),
+                    span.bytes
+                )));
+            }
+            EngineDevice::upload(&*self.be, dst, span.dst_off, bytes)?;
+            moved += span.bytes;
+        }
+        Ok(moved)
+    }
+
     pub fn kv_rebase(&mut self, slot: usize) -> Result<()> {
         if self.kv_slot == slot || self.kv_slot_stride.is_empty() {
             return Ok(());

--- a/crates/plowrt/src/exec/cpu/engine.rs
+++ b/crates/plowrt/src/exec/cpu/engine.rs
@@ -924,6 +924,38 @@ impl CpuModel {
         unsafe { *self.table.as_ptr().add(h) }
     }
 
+    /// Read-only view of `len` bytes at `off` inside tensor `handle`.
+    ///
+    /// The head prefill's KV rows are already host memory, so a handoff reads
+    /// its source straight out of the tensor rather than staging a copy of it.
+    ///
+    /// Addresses the tensor's BASE allocation, NOT [`Self::table_ptr`], which
+    /// may be slot-rebased by [`Self::kv_rebase`]. A handoff plan already
+    /// carries the slot in its offset, so reading through the rebased pointer
+    /// would apply the slot twice.
+    ///
+    /// Bounds-checked because the caller's offsets come from a plan derived
+    /// from the OTHER packet's declarations, and the whole point of the KV
+    /// contract is that the two agreeing is checked rather than assumed.
+    pub fn tensor_range(&self, handle: usize, off: u64, len: u64) -> Result<&[u8]> {
+        let t = self
+            .tensors
+            .get(handle)
+            .ok_or_else(|| RuntimeError::Rejected(format!("tensor handle {handle} out of range")))?;
+        let end = off.checked_add(len).ok_or_else(|| {
+            RuntimeError::Rejected(format!("tensor {handle} range {off}+{len} overflows"))
+        })?;
+        if end > t.bytes as u64 {
+            return Err(RuntimeError::Rejected(format!(
+                "tensor {handle} range {off}+{len} past its {} bytes",
+                t.bytes
+            )));
+        }
+        // SAFETY: `handle` indexes this model's own allocation, the range is
+        // inside it, and `&self` keeps it alive and unwritten for the borrow.
+        Ok(unsafe { std::slice::from_raw_parts(t.as_ptr().add(off as usize), len as usize) })
+    }
+
     /// Decode rungs (sequence widths), ascending, one per decode program.
     pub fn decode_rungs(&self) -> Vec<u32> {
         self.blob.progs[self.dec_ix..].iter().map(|p| p.t).collect()
@@ -1578,6 +1610,12 @@ pub struct CpuEngineOpts {
     pub numa: NumaMode,
     pub isa: Isa,
     pub spin_us: u32,
+    /// Cores this engine's workers may use. `None` = the live topology.
+    ///
+    /// Set by the prefill-head pool to its reservation, so `WorkerPool` places
+    /// heads inside it with the machinery it already has and the serving path's
+    /// cores are simply not in the set it can see.
+    pub topology: Option<Topology>,
 }
 
 impl Default for CpuEngineOpts {
@@ -1587,6 +1625,7 @@ impl Default for CpuEngineOpts {
             numa: NumaMode::Auto,
             isa: Isa::Amx,
             spin_us: 2000,
+            topology: None,
         }
     }
 }
@@ -1659,7 +1698,7 @@ pub struct CpuEngine {
 impl CpuEngine {
     pub fn load(blob: &Path, checkpoint: &Path, opts: &CpuEngineOpts) -> Result<CpuEngine> {
         let isa = ffi::init(opts.isa)?;
-        let topo = Topology::detect();
+        let topo = opts.topology.clone().unwrap_or_else(Topology::detect);
         if let NumaMode::Nodes(requested) = &opts.numa {
             if requested.is_empty() || requested.iter().any(|n| !topo.nodes.contains(n)) {
                 return Err(RuntimeError::Device(format!(

--- a/crates/plowrt/src/exec/engine_thread.rs
+++ b/crates/plowrt/src/exec/engine_thread.rs
@@ -23,11 +23,24 @@ pub struct EngineThread {
 
 impl EngineThread {
     /// Spawn the named worker thread. It exits when the handle drops.
+    ///
+    /// Pins itself to the serving reservation when heterogeneous prefill is
+    /// configured. The serving path is pinned FIRST and deliberately: reserving
+    /// cores for the head pool while the thread being protected floats reserves
+    /// nothing. With the feature off the reservation is empty and no affinity
+    /// call is made, so the default build places this thread exactly as before.
     pub fn spawn(name: String) -> EngineThread {
         let (tx, rx) = std::sync::mpsc::channel::<Job>();
         std::thread::Builder::new()
             .name(name)
             .spawn(move || {
+                #[cfg(feature = "cpu")]
+                {
+                    let serving = &crate::exec::affinity::plan().serving;
+                    if !serving.is_empty() {
+                        crate::exec::affinity::pin(serving);
+                    }
+                }
                 while let Ok(job) = rx.recv() {
                     job();
                 }

--- a/crates/plowrt/src/exec/kv_handoff.rs
+++ b/crates/plowrt/src/exec/kv_handoff.rs
@@ -1,0 +1,301 @@
+//! Planning the byte copies that move a CPU-prefilled head's KV rows into a
+//! device sequence slot.
+//!
+//! Pure functions over the device ISA and the packet's tensor table, like
+//! [`super::kvrow`], so the addressing can be tested without a device. Getting
+//! it wrong is not a fault: it is a slot whose rows `[0, n)` hold the right
+//! bytes at the wrong offsets, which reads as fluent wrong output.
+//!
+//! ## Only seq-major caches, and the packet says which those are
+//!
+//! A row range is one contiguous run inside a slot only when the cache's
+//! sequence axis is its outer one. The two families in the ISA differ here:
+//!
+//! * **MLA** declares `kv.{l}.ckv` as `dbatch × ctx × dk` and `kv.{l}.krot` as
+//!   `dbatch × ctx × dr` (`devgen::mla`) — `[slot][seq][width]`. Rows `[0, n)`
+//!   are one run of `n × row_bytes`.
+//! * **Dense GQA** declares `kv.{l}.k` as `dbatch × kv_heads × ring × head_dim`
+//!   (`devgen::gptoss`) — `[slot][head][seq][dim]`. The same rows are
+//!   `kv_heads` runs strided by the ring, and a single-run copy would write
+//!   head 0's rows over the front of head 0 and nothing else correctly.
+//!
+//! The discriminator is already in the tree and already load-bearing:
+//! `rebase_chunk_rows` separates the two by `HeadNormRope`'s `fj[1]`, the KV
+//! ring stride, which dense GQA sets and MLA's k_rope leaves at zero. So the
+//! head-major case is REFUSED BY NAME here rather than addressed by a guess.
+//! Supporting it is a scatter plus the head count, which the packet also
+//! carries; it is not in this path yet.
+
+use packet::dev::{DevInst64, DevOp};
+
+use super::kvrow::KvSlotTensor;
+use crate::{Result, RuntimeError};
+
+/// One planned byte copy: `bytes` from `src_off` in the head's slot to
+/// `dst_off` in the device slot, both offsets relative to the tensor's base.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CopySpan {
+    /// Index into the packet's tensor table — the same handle on both sides,
+    /// which the KV contract digest is what guarantees.
+    pub handle: usize,
+    pub src_off: u64,
+    pub dst_off: u64,
+    pub bytes: u64,
+}
+
+/// Refuse a prefill program whose KV caches are not addressable as row ranges.
+///
+/// Called at load, so a model that cannot hand off says so once rather than
+/// producing a wrong answer per request.
+pub(crate) fn check_seq_major(insts: &[DevInst64], names: &[String]) -> Result<()> {
+    for d in insts {
+        let head_major = (d.op == DevOp::HeadNormRope as u16
+            || d.op == DevOp::HeadNormRopeFp8 as u16)
+            && d.fj[1] != 0;
+        if !head_major {
+            continue;
+        }
+        let dst = names.get(d.t[0] as usize).map(String::as_str).unwrap_or("?");
+        return Err(RuntimeError::Device(format!(
+            "CPU head prefill needs seq-major KV caches; `{dst}` is written with a KV ring \
+             stride (head-major `[slot][head][seq][dim]`), so its rows are a strided scatter \
+             rather than one run. Head-major handoff is not implemented."
+        )));
+    }
+    Ok(())
+}
+
+/// How many prompt rows one entry of each cache covers, for the caches where
+/// that is not 1.
+///
+/// The DSA pooled indexer key cache holds one softmax-pooled vector per
+/// `index_kpool` consecutive tokens (`devgen::mla`), so its slot is
+/// `ctx / pool` entries, not `ctx`. `DsaPoolCompress` is the instruction that
+/// writes it and carries the pool size in `i[1]`.
+///
+/// **This has to be read off the packet; arithmetic does not find it.** A
+/// pooled cache's per-slot extent is usually still divisible by the context —
+/// `(ctx/pool) × width` divides `ctx` whenever `pool` divides `width` — so a
+/// divisibility check accepts it and then copies `rows × (per_slot/ctx)` bytes,
+/// which is the wrong length by exactly the pooling factor. Silent, and wrong
+/// in the direction that leaves the indexer scoring against stale keys.
+pub(crate) fn pooled_caches(insts: &[DevInst64], names: &[String]) -> Vec<(String, u32)> {
+    let mut out: Vec<(String, u32)> = Vec::new();
+    for d in insts {
+        if d.op != DevOp::DsaPoolCompress as u16 {
+            continue;
+        }
+        let Some(name) = names.get(d.t[0] as usize) else {
+            continue;
+        };
+        let pool = d.i[1].max(1);
+        if pool > 1 && !out.iter().any(|(n, _)| n == name) {
+            out.push((name.clone(), pool));
+        }
+    }
+    out
+}
+
+/// Plan the copies moving `rows` prompt rows from `src_slot` of the head engine
+/// into `dst_slot` of the device engine.
+///
+/// `rows_per_slot` is the compiled context. `pools` is [`pooled_caches`]; a
+/// cache named there advances one entry per `pool` prompt rows, so a head must
+/// end on a pool boundary — a head stopping mid-group would hand over an entry
+/// pooled from only part of its tokens, and the device would not recompute it.
+pub(crate) fn plan(
+    tensors: &[KvSlotTensor],
+    rows_per_slot: u32,
+    pools: &[(String, u32)],
+    src_slot: u32,
+    dst_slot: u32,
+    rows: u32,
+) -> Result<Vec<CopySpan>> {
+    if rows == 0 {
+        return Ok(Vec::new());
+    }
+    if rows_per_slot == 0 || rows > rows_per_slot {
+        return Err(RuntimeError::Rejected(format!(
+            "head of {rows} rows past the compiled context {rows_per_slot}"
+        )));
+    }
+    let mut plan = Vec::with_capacity(tensors.len());
+    for t in tensors {
+        let pool = pools
+            .iter()
+            .find(|(n, _)| *n == t.name)
+            .map(|&(_, p)| p)
+            .unwrap_or(1);
+        if !rows.is_multiple_of(pool) {
+            return Err(RuntimeError::Rejected(format!(
+                "head of {rows} rows does not end on a pool boundary of `{}` (pool {pool}); \
+                 the boundary entry would be pooled from part of its tokens",
+                t.name
+            )));
+        }
+        if !rows_per_slot.is_multiple_of(pool) {
+            return Err(RuntimeError::Device(format!(
+                "pooled cache `{}` has pool {pool}, which does not divide the compiled context \
+                 {rows_per_slot}",
+                t.name
+            )));
+        }
+        let entries_per_slot = u64::from(rows_per_slot / pool);
+        if !t.per_slot_bytes.is_multiple_of(entries_per_slot) {
+            return Err(RuntimeError::Device(format!(
+                "KV cache `{}` holds {} bytes per slot, not a whole number of entries at \
+                 context {rows_per_slot} pool {pool}; its rows are not addressable as a byte \
+                 range",
+                t.name, t.per_slot_bytes
+            )));
+        }
+        let entry_bytes = t.per_slot_bytes / entries_per_slot;
+        if entry_bytes == 0 {
+            continue;
+        }
+        plan.push(CopySpan {
+            handle: t.handle,
+            src_off: u64::from(src_slot) * t.per_slot_bytes,
+            dst_off: u64::from(dst_slot) * t.per_slot_bytes,
+            bytes: u64::from(rows / pool) * entry_bytes,
+        });
+    }
+    Ok(plan)
+}
+
+/// Total bytes a plan moves — the transfer term the head budget prices.
+pub(crate) fn plan_bytes(plan: &[CopySpan]) -> u64 {
+    plan.iter().map(|c| c.bytes).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(handle: usize, name: &str, per_slot_bytes: u64) -> KvSlotTensor {
+        KvSlotTensor {
+            handle,
+            name: name.to_string(),
+            per_slot_bytes,
+        }
+    }
+
+    /// GLM MLA at ctx 8: `ckv` is 512 wide bf16, `krot` 64 wide bf16.
+    fn mla() -> Vec<KvSlotTensor> {
+        vec![t(3, "kv.0.ckv", 8 * 512 * 2), t(4, "kv.0.krot", 8 * 64 * 2)]
+    }
+
+    #[test]
+    fn a_head_is_one_run_per_cache_at_the_front_of_each_slot() {
+        let p = plan(&mla(), 8, &[], 0, 0, 3).unwrap();
+        assert_eq!(
+            p,
+            vec![
+                CopySpan { handle: 3, src_off: 0, dst_off: 0, bytes: 3 * 512 * 2 },
+                CopySpan { handle: 4, src_off: 0, dst_off: 0, bytes: 3 * 64 * 2 },
+            ]
+        );
+    }
+
+    #[test]
+    fn the_head_slot_and_the_device_slot_are_independent() {
+        // The head pool's slot count has nothing to do with the GPU batch, so
+        // the two indices must be applied to their own sides and not swapped.
+        let p = plan(&mla(), 8, &[], 1, 5, 2).unwrap();
+        assert_eq!(p[0].src_off, 8 * 512 * 2);
+        assert_eq!(p[0].dst_off, 5 * 8 * 512 * 2);
+        assert_eq!(p[0].bytes, 2 * 512 * 2);
+    }
+
+    #[test]
+    fn a_zero_row_head_moves_nothing() {
+        assert!(plan(&mla(), 8, &[], 0, 0, 0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_head_cannot_run_past_the_compiled_context() {
+        let err = plan(&mla(), 8, &[], 0, 0, 9).unwrap_err().to_string();
+        assert!(err.contains("past the compiled context 8"), "{err}");
+        // The whole context is legal: that is the whole-request case.
+        assert!(plan(&mla(), 8, &[], 0, 0, 8).is_ok());
+    }
+
+    /// The defect a divisibility check does NOT catch, pinned: `kv.0.kidx` at
+    /// pool 4 holds 2 entries per slot of 64 bytes each, and 128 bytes IS
+    /// divisible by the context 8. Treating it as 8 rows of 16 copies a
+    /// quarter of the bytes a 4-row head owes.
+    #[test]
+    fn a_pooled_cache_is_copied_by_entries_not_rows() {
+        let pooled = vec![t(7, "kv.0.kidx", 2 * 64)];
+        let pools = [("kv.0.kidx".to_string(), 4u32)];
+        let p = plan(&pooled, 8, &pools, 0, 0, 4).unwrap();
+        assert_eq!(p[0].bytes, 64, "one pooled entry, not four rows of 16");
+        // Unpooled, the same tensor would have been read as 8 rows of 16.
+        assert_eq!(plan(&pooled, 8, &[], 0, 0, 4).unwrap()[0].bytes, 4 * 16);
+    }
+
+    #[test]
+    fn a_head_must_end_on_a_pool_boundary() {
+        let pooled = vec![t(7, "kv.0.kidx", 2 * 64)];
+        let pools = [("kv.0.kidx".to_string(), 4u32)];
+        let err = plan(&pooled, 8, &pools, 0, 0, 6).unwrap_err().to_string();
+        assert!(err.contains("pool boundary"), "{err}");
+        assert!(err.contains("kv.0.kidx"), "{err}");
+    }
+
+    #[test]
+    fn a_pool_size_is_read_off_the_compress_instruction() {
+        let names = vec!["x".to_string(), "kv.0.kidx".to_string()];
+        let mut d = inst(DevOp::DsaPoolCompress, 1, 0);
+        d.i[1] = 4;
+        assert_eq!(
+            pooled_caches(&[d], &names),
+            vec![("kv.0.kidx".to_string(), 4)]
+        );
+        // pool 1 is the no-op path GLM ships by default: not a pooled cache.
+        let mut one = inst(DevOp::DsaPoolCompress, 1, 0);
+        one.i[1] = 1;
+        assert!(pooled_caches(&[one], &names).is_empty());
+    }
+
+    #[test]
+    fn plan_bytes_is_what_the_budget_prices() {
+        let p = plan(&mla(), 8, &[], 0, 0, 3).unwrap();
+        assert_eq!(plan_bytes(&p), 3 * (512 + 64) * 2);
+    }
+
+    fn inst(op: DevOp, dst: u16, ring_stride: u32) -> DevInst64 {
+        let mut d = DevInst64 {
+            op: op as u16,
+            ..Default::default()
+        };
+        d.t[0] = dst;
+        d.fj[1] = ring_stride;
+        d
+    }
+
+    #[test]
+    fn a_ring_strided_cache_write_refuses_the_head_path() {
+        let names = vec!["x".to_string(), "kv.0.k".to_string()];
+        let insts = [inst(DevOp::HeadNormRope, 1, 4096)];
+        let err = check_seq_major(&insts, &names).unwrap_err().to_string();
+        assert!(err.contains("kv.0.k"), "{err}");
+        assert!(err.contains("head-major"), "{err}");
+    }
+
+    #[test]
+    fn mla_k_rope_leaves_the_ring_stride_at_zero_and_is_accepted() {
+        let names = vec!["x".to_string(), "kv.0.krot".to_string()];
+        // Same opcode as the dense-GQA write; `fj[1]` is the whole difference.
+        let insts = [inst(DevOp::HeadNormRope, 1, 0)];
+        assert!(check_seq_major(&insts, &names).is_ok());
+    }
+
+    #[test]
+    fn the_fp8_twin_is_checked_too() {
+        // A bf16-only test silently matches nothing on an fp8-KV packet.
+        let names = vec!["x".to_string(), "kv.0.k".to_string()];
+        let insts = [inst(DevOp::HeadNormRopeFp8, 1, 4096)];
+        assert!(check_seq_major(&insts, &names).is_err());
+    }
+}

--- a/crates/plowrt/src/exec/kvrow.rs
+++ b/crates/plowrt/src/exec/kvrow.rs
@@ -499,3 +499,64 @@ pub(crate) fn derive_mla_nsplit(insts: &[DevInst64]) -> Option<(Vec<u32>, u32)> 
     }
     (n_flash > 0 && n_flash == n_merge).then_some((sites, baked?))
 }
+
+/// One transferable KV cache in a loaded packet: where the engine's tensor
+/// table holds it, and the geometry the twin must match.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct KvSlotTensor {
+    /// Index into the packet's tensor table.
+    pub handle: usize,
+    pub name: String,
+    pub per_slot_bytes: u64,
+}
+
+/// The transferable KV set for a packet whose `kv.*` caches are `[batch]` slot
+/// blocks, sorted by name.
+///
+/// Sorted because the digest is a set comparison across two INDEPENDENT emits:
+/// the device packet and its CPU twin need not declare tensors in the same
+/// order, and a digest that depended on that order would refuse every valid
+/// pair.
+///
+/// This is deliberately NOT `AmdEngine`'s `kv_slot_stride`, which keeps the
+/// carried recurrent state when the blob's `PLOW_KDA_F_SEQ_ROWS` carrier says
+/// it is per-slot. A row range does not reconstruct a recurrence, so the head
+/// path excludes it here and refuses the model at admission instead.
+pub(crate) fn kv_slot_tensors(
+    blob: &crate::asset::devblob::DevBlob,
+    batch: u32,
+) -> crate::Result<Vec<KvSlotTensor>> {
+    let batch = u64::from(batch.max(1));
+    let mut out = Vec::new();
+    for (handle, t) in blob.tensors.iter().enumerate() {
+        if !plow_asset::kv_contract::is_cache_tensor(&t.name) {
+            continue;
+        }
+        if !t.bytes.is_multiple_of(batch) {
+            return Err(crate::RuntimeError::Device(format!(
+                "KV cache tensor `{}` has {} bytes, not divisible by batch {batch}",
+                t.name, t.bytes
+            )));
+        }
+        out.push(KvSlotTensor {
+            handle,
+            name: t.name.clone(),
+            per_slot_bytes: t.bytes / batch,
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+/// The digest a device packet and its CPU twin must agree on before a head's KV
+/// rows may be copied between them.
+pub(crate) fn kv_contract_digest(tensors: &[KvSlotTensor]) -> String {
+    let set: Vec<_> = tensors
+        .iter()
+        .map(|t| plow_asset::kv_contract::CacheTensor {
+            name: t.name.clone(),
+            per_slot_bytes: t.per_slot_bytes,
+        })
+        .collect();
+    plow_asset::kv_contract::digest(&set)
+}

--- a/crates/plowrt/src/exec/kvrow.rs
+++ b/crates/plowrt/src/exec/kvrow.rs
@@ -500,8 +500,14 @@ pub(crate) fn derive_mla_nsplit(insts: &[DevInst64]) -> Option<(Vec<u32>, u32)> 
     (n_flash > 0 && n_flash == n_merge).then_some((sites, baked?))
 }
 
+// The KV contract has no caller until the head handoff lands. Keep it here
+// rather than deferring it: the transferable-set rule belongs beside the other
+// KV-row rules this module exists to hold in one place, and splitting it across
+// commits is how the two engines' notions of "which tensors carry a sequence"
+// drifted apart before.
 /// One transferable KV cache in a loaded packet: where the engine's tensor
 /// table holds it, and the geometry the twin must match.
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct KvSlotTensor {
     /// Index into the packet's tensor table.
@@ -522,6 +528,7 @@ pub(crate) struct KvSlotTensor {
 /// carried recurrent state when the blob's `PLOW_KDA_F_SEQ_ROWS` carrier says
 /// it is per-slot. A row range does not reconstruct a recurrence, so the head
 /// path excludes it here and refuses the model at admission instead.
+#[allow(dead_code)]
 pub(crate) fn kv_slot_tensors(
     blob: &crate::asset::devblob::DevBlob,
     batch: u32,
@@ -550,6 +557,7 @@ pub(crate) fn kv_slot_tensors(
 
 /// The digest a device packet and its CPU twin must agree on before a head's KV
 /// rows may be copied between them.
+#[allow(dead_code)]
 pub(crate) fn kv_contract_digest(tensors: &[KvSlotTensor]) -> String {
     let set: Vec<_> = tensors
         .iter()

--- a/crates/plowrt/src/exec/mod.rs
+++ b/crates/plowrt/src/exec/mod.rs
@@ -16,6 +16,11 @@ mod amd_packed;
 /// all-ranks, with a host barrier — see the module note for why the two differ.
 #[cfg(feature = "hsa")]
 pub mod amd_tp;
+/// Core reservation and thread priority for the CPU prefill-head pool. Gated on
+/// `cpu` because a head runs on `exec::cpu`, so a build without it has no head
+/// to place — and that is also where `libc` enters the dependency set.
+#[cfg(feature = "cpu")]
+pub mod affinity;
 /// Apple Neural Engine executor: CoreML programs built from plow weights, run at segment
 /// boundaries of the Metal walk. See `plans/apple-silicon-backend.md` §4.5.
 #[cfg(all(feature = "ane", target_os = "macos"))]

--- a/crates/plowrt/src/exec/mod.rs
+++ b/crates/plowrt/src/exec/mod.rs
@@ -49,6 +49,12 @@ pub mod indirection;
 // Prefill-chunk helpers are only exercised by an engine with a prefill path (AMD today).
 #[cfg_attr(not(feature = "hsa"), allow(dead_code))]
 pub mod kvrow;
+/// Byte-copy planning for a CPU-prefilled head's KV rows.
+// Allowed dead until the head pool calls it. The planning rules are tested on
+// their own and land with the KV contract they depend on, rather than arriving
+// in the same commit as the pool that drives them.
+#[allow(dead_code)]
+pub mod kv_handoff;
 pub mod mixed_packet;
 #[cfg(feature = "hsa")]
 pub(crate) mod mixed_program;

--- a/crates/plowrt/src/main.rs
+++ b/crates/plowrt/src/main.rs
@@ -3156,6 +3156,9 @@ async fn bringup_runtime(
                     }
                 },
                 spin_us: cpu.spin_us,
+                // The served model takes the live topology; only a head pool
+                // narrows it to a reservation.
+                topology: None,
             };
             tracing::info!(
                 %slug, blob = %blob.display(), checkpoint = %ckpt.display(), ?opts,

--- a/crates/plowrt/src/sched/het.rs
+++ b/crates/plowrt/src/sched/het.rs
@@ -1,0 +1,407 @@
+//! Deciding whether a queued request's prompt head runs on the CPU, and how
+//! long a head that does may be.
+//!
+//! A head exists only because a queue exists. Every decision here is driven by
+//! the estimates the mux already publishes — `LoadEstimator`'s arrival EWMA and
+//! measured service time, and `predicted_wait_ms` — so this adds a policy over
+//! the admission signals rather than a second scheduler.
+//!
+//! Pure: no engine, no device, no clock. The mux supplies the numbers.
+
+use rustc_hash::FxHashMap;
+
+/// Utilisation at or above which a head may run. The same threshold
+/// `sched::admission::admit` uses to separate "run now" from "hold to form a
+/// batch", for the same reason: below it there is no wait to hide a head in, so
+/// a head is pure added TTFT.
+pub const ARM_UTIL: f64 = 0.85;
+/// Utilisation below which the head pool disarms. Lower than [`ARM_UTIL`] so a
+/// burst does not flap the pool in and out of its spin state.
+pub const DISARM_UTIL: f64 = 0.75;
+
+/// What one CPU head pass costs, measured per model on the serving host.
+///
+/// `fixed_ms` dominates for a big MoE — a pass streams the weight set from DRAM
+/// and 28 rows read almost what 512 do — so a head is budgeted in wall time and
+/// there is no saving in running a shorter one than the wait affords.
+#[derive(Clone, Copy, Debug)]
+pub struct HeadCost {
+    pub fixed_ms: f64,
+    pub per_row_ms: f64,
+    /// KV bytes one prompt row adds to the handoff.
+    pub xfer_bytes_per_row: u64,
+    /// Effective host-to-device bandwidth for the handoff.
+    pub xfer_bytes_per_ms: f64,
+}
+
+impl HeadCost {
+    /// Wall time of a head of `rows`, including the transfer that must land
+    /// before the device may run the body.
+    pub fn total_ms(&self, rows: u32) -> f64 {
+        let compute = self.fixed_ms + self.per_row_ms * f64::from(rows);
+        let xfer = if self.xfer_bytes_per_ms > 0.0 {
+            (self.xfer_bytes_per_row * u64::from(rows)) as f64 / self.xfer_bytes_per_ms
+        } else {
+            0.0
+        };
+        compute + xfer
+    }
+
+    /// Largest head that finishes and transfers inside `wait_ms`, leaving
+    /// `margin_ms` for the tick that will admit the request.
+    ///
+    /// Zero when the fixed cost alone does not fit: a head that will not
+    /// complete is one the device abandons, so starting it buys nothing.
+    pub fn budget_rows(&self, wait_ms: f64, margin_ms: f64, cap: u32) -> u32 {
+        let have = wait_ms - margin_ms;
+        if have <= 0.0 || self.total_ms(0) > have {
+            return 0;
+        }
+        let per_row = self.per_row_ms
+            + if self.xfer_bytes_per_ms > 0.0 {
+                self.xfer_bytes_per_row as f64 / self.xfer_bytes_per_ms
+            } else {
+                0.0
+            };
+        if per_row <= 0.0 {
+            return cap;
+        }
+        let rows = ((have - self.fixed_ms) / per_row).floor();
+        if rows <= 0.0 {
+            return 0;
+        }
+        (rows as u64).min(u64::from(cap)) as u32
+    }
+}
+
+/// A head the planner decided to run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HetPlan {
+    pub head_rows: u32,
+}
+
+/// Choose a head length for a prompt of `prompt_rows` facing `wait_ms` of
+/// queue: the LARGEST head the wait affords.
+///
+/// # There is deliberately no snap to a rung boundary
+///
+/// The obvious refinement is to nudge the head so the device is left a whole
+/// number of compiled rungs. It cannot help, and the reason is the same
+/// property that makes any head cover-safe: **device cost is monotone
+/// non-increasing in rows removed.** AMD's ragged cover is
+/// `ceil(rows / max_bucket)` launches, and any cover valid for `r + 1` rows is
+/// valid for `r`, so NVIDIA's DP cost cannot rise as rows fall either.
+///
+/// A larger head is therefore never a worse cover than a smaller one, and the
+/// largest affordable head already lands on or past whatever boundary a snap
+/// would have aimed for. Alignment is subsumed, not forgone: if the budget
+/// reaches the remainder, the rung is won automatically; if it does not, no
+/// choice within the window would have won it either.
+///
+/// This is also why the backend's cover planner is neither called nor
+/// reimplemented here. It stays exactly as it is, and this cannot disagree with
+/// it.
+///
+/// `min_gpu_rows` keeps real work on the device: a head must not quietly grow
+/// into a CPU-served request, which is a separate decision with its own quality
+/// contract.
+pub fn plan_head(
+    util: f64,
+    wait_ms: f64,
+    prompt_rows: u32,
+    cost: &HeadCost,
+    cap: u32,
+    margin_ms: f64,
+    min_gpu_rows: u32,
+) -> Option<HetPlan> {
+    if util < ARM_UTIL {
+        return None;
+    }
+    let headroom = prompt_rows.saturating_sub(min_gpu_rows);
+    let head_rows = cost.budget_rows(wait_ms, margin_ms, cap).min(headroom);
+    (head_rows > 0).then_some(HetPlan { head_rows })
+}
+
+/// Arming hysteresis: the head pool follows the queue, not each tick.
+#[derive(Clone, Debug, Default)]
+pub struct Arm {
+    armed: bool,
+    hi_ticks: u32,
+}
+
+impl Arm {
+    /// Fold one tick's utilisation in and return whether heads may run.
+    ///
+    /// Disarming is immediate in both of its causes — falling load and a
+    /// tripped contention guard — while arming needs `needed` consecutive busy
+    /// ticks. Asymmetric on purpose: the cost of arming late is a missed
+    /// offload, the cost of disarming late is GPU tick latency.
+    pub fn observe(&mut self, util: f64, guard_tripped: bool, needed: u32) -> bool {
+        if guard_tripped || util < DISARM_UTIL {
+            self.armed = false;
+            self.hi_ticks = 0;
+            return false;
+        }
+        if util >= ARM_UTIL {
+            self.hi_ticks = self.hi_ticks.saturating_add(1);
+            if self.hi_ticks >= needed.max(1) {
+                self.armed = true;
+            }
+        } else {
+            self.hi_ticks = 0;
+        }
+        self.armed
+    }
+
+    pub fn armed(&self) -> bool {
+        self.armed
+    }
+}
+
+/// The closed-loop half of the non-regression guarantee.
+///
+/// Affinity and `SCHED_IDLE` bound what the head pool can preempt; neither
+/// bounds memory bandwidth or PCIe, and those leak through static isolation. So
+/// the guard watches the statistic the runtime already maintains — the mux's
+/// measured per-tick service time — against what it was with the pool idle, and
+/// disarms when the armed value drifts past a limit.
+///
+/// **Baselines are per shape.** Service time is a function of the decode rung
+/// and live batch, so one global baseline would trip on a rung change and stay
+/// silent through real contention at another. A shape never seen disarmed is
+/// not judged at all: no baseline, no verdict, rather than a guess.
+pub struct ContentionGuard {
+    baseline_ms: FxHashMap<u32, f64>,
+    breaches: u32,
+    tripped: bool,
+    limit_pct: f64,
+    needed: u32,
+    alpha: f64,
+}
+
+impl ContentionGuard {
+    pub fn new(limit_pct: f64, needed: u32) -> Self {
+        ContentionGuard {
+            baseline_ms: FxHashMap::default(),
+            breaches: 0,
+            tripped: false,
+            limit_pct,
+            needed: needed.max(1),
+            alpha: 0.2,
+        }
+    }
+
+    /// Record a tick that ran with the head pool idle.
+    pub fn observe_disarmed(&mut self, shape: u32, service_ms: f64) {
+        if service_ms <= 0.0 {
+            return;
+        }
+        let e = self.baseline_ms.entry(shape).or_insert(service_ms);
+        *e = self.alpha * service_ms + (1.0 - self.alpha) * *e;
+    }
+
+    /// Record a tick that ran with heads in flight; returns whether the guard
+    /// is now tripped.
+    pub fn observe_armed(&mut self, shape: u32, service_ms: f64) -> bool {
+        let Some(&base) = self.baseline_ms.get(&shape) else {
+            return self.tripped;
+        };
+        if service_ms > base * (1.0 + self.limit_pct / 100.0) {
+            self.breaches += 1;
+            if self.breaches >= self.needed {
+                self.tripped = true;
+            }
+        } else {
+            self.breaches = 0;
+        }
+        self.tripped
+    }
+
+    pub fn tripped(&self) -> bool {
+        self.tripped
+    }
+
+    /// Clear the trip after a quiet period. The baselines are kept: they
+    /// describe the machine, not the episode.
+    pub fn rearm(&mut self) {
+        self.tripped = false;
+        self.breaches = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A big MoE: the pass streams the weight set, so it is fixed-cost heavy.
+    fn moe() -> HeadCost {
+        HeadCost {
+            fixed_ms: 800.0,
+            per_row_ms: 2.0,
+            xfer_bytes_per_row: 88_000,
+            xfer_bytes_per_ms: 50_000_000.0,
+        }
+    }
+
+    #[test]
+    fn no_queue_means_no_head() {
+        // Below the arm threshold there is no wait to hide the pass in.
+        assert_eq!(plan_head(0.5, 5_000.0, 4096, &moe(), 4096, 50.0, 128), None);
+    }
+
+    #[test]
+    fn a_wait_shorter_than_the_fixed_pass_buys_nothing() {
+        // The head would be abandoned before it completed, so it is not started.
+        assert_eq!(plan_head(0.95, 700.0, 4096, &moe(), 4096, 50.0, 128), None);
+        assert_eq!(moe().budget_rows(700.0, 50.0, 4096), 0);
+        // Just past the fixed cost the head is small but real: 800 ms of idle
+        // CPU for 24 rows is a poor rate and a free one, and those are rows the
+        // device does not run.
+        assert_eq!(moe().budget_rows(900.0, 50.0, 4096), 24);
+    }
+
+    #[test]
+    fn a_deep_queue_affords_a_real_head() {
+        // The conc=20 regime: minutes of wait, so the budget is rows not tokens.
+        let n = moe().budget_rows(30_000.0, 50.0, 100_000);
+        assert!(n > 5_000, "budget was {n}");
+        // The transfer is part of the budget, not a footnote: at 88 KB/row it
+        // is ~1.76 ms per 1000 rows against 2 ms/row of compute.
+        let with_xfer = moe().total_ms(n);
+        assert!(with_xfer <= 30_000.0 - 50.0, "budget overruns the wait");
+    }
+
+    #[test]
+    fn the_budget_leaves_a_margin_for_the_admitting_tick() {
+        let cost = HeadCost {
+            fixed_ms: 0.0,
+            per_row_ms: 1.0,
+            xfer_bytes_per_row: 0,
+            xfer_bytes_per_ms: 0.0,
+        };
+        assert_eq!(cost.budget_rows(1_000.0, 200.0, 10_000), 800);
+    }
+
+    #[test]
+    fn a_head_never_consumes_the_whole_prompt() {
+        // min_gpu_rows keeps real work on the device: a head must not quietly
+        // become a CPU-served request.
+        let cost = HeadCost {
+            fixed_ms: 0.0,
+            per_row_ms: 0.001,
+            xfer_bytes_per_row: 0,
+            xfer_bytes_per_ms: 0.0,
+        };
+        let p = plan_head(0.95, 1e9, 4096, &cost, u32::MAX, 0.0, 128).unwrap();
+        assert_eq!(p.head_rows, 4096 - 128);
+    }
+
+    /// The 4124-row case, and why no rung snap is needed to serve it.
+    ///
+    /// A ladder stepping at 4096 makes "leave the device 4096 rows" the cheap
+    /// cover, reached by a 28-row head. A budget that affords 40 rows takes 40
+    /// — leaving 4084, still one rung, and twelve more rows the device does not
+    /// run. Snapping back to 28 would have been strictly worse.
+    #[test]
+    fn a_budget_past_the_rung_boundary_keeps_the_extra_rows() {
+        let cover = |rows: u32| if rows <= 4096 { 1u64 } else { 2 };
+        let cost = HeadCost {
+            fixed_ms: 0.0,
+            per_row_ms: 0.001,
+            xfer_bytes_per_row: 0,
+            xfer_bytes_per_ms: 0.0,
+        };
+        let p = plan_head(0.95, 40.0, 4124, &cost, 40, 0.0, 1).unwrap();
+        assert_eq!(p.head_rows, 40);
+        assert_eq!(cover(4124 - p.head_rows), 1, "the rung is won anyway");
+    }
+
+    /// And when the budget does not reach the boundary, no choice would have.
+    #[test]
+    fn a_budget_short_of_the_boundary_cannot_win_the_rung_either() {
+        let cover = |rows: u32| if rows <= 4096 { 1u64 } else { 2 };
+        let cost = HeadCost {
+            fixed_ms: 0.0,
+            per_row_ms: 0.001,
+            xfer_bytes_per_row: 0,
+            xfer_bytes_per_ms: 0.0,
+        };
+        let p = plan_head(0.95, 20.0, 4124, &cost, 20, 0.0, 1).unwrap();
+        assert_eq!(p.head_rows, 20);
+        assert_eq!(cover(4124 - p.head_rows), 2);
+    }
+
+    #[test]
+    fn arming_needs_a_sustained_queue_but_disarming_is_immediate() {
+        let mut arm = Arm::default();
+        assert!(!arm.observe(0.9, false, 3));
+        assert!(!arm.observe(0.9, false, 3));
+        assert!(arm.observe(0.9, false, 3));
+        // One quiet tick inside the band keeps it armed (hysteresis).
+        assert!(arm.observe(0.8, false, 3));
+        // Below the disarm threshold it drops at once.
+        assert!(!arm.observe(0.7, false, 3));
+        // And re-arming starts the count over.
+        assert!(!arm.observe(0.9, false, 3));
+    }
+
+    #[test]
+    fn a_tripped_guard_disarms_regardless_of_load() {
+        let mut arm = Arm::default();
+        for _ in 0..5 {
+            arm.observe(0.99, false, 3);
+        }
+        assert!(arm.armed());
+        assert!(!arm.observe(0.99, true, 3));
+    }
+
+    #[test]
+    fn contention_trips_only_after_sustained_regression() {
+        let mut g = ContentionGuard::new(5.0, 3);
+        for _ in 0..10 {
+            g.observe_disarmed(8, 100.0);
+        }
+        // Inside the limit: no breach.
+        assert!(!g.observe_armed(8, 104.0));
+        // Past it, but not yet for long enough.
+        assert!(!g.observe_armed(8, 120.0));
+        assert!(!g.observe_armed(8, 120.0));
+        assert!(g.observe_armed(8, 120.0));
+        assert!(g.tripped());
+    }
+
+    #[test]
+    fn a_run_of_good_ticks_clears_the_breach_count() {
+        let mut g = ContentionGuard::new(5.0, 3);
+        g.observe_disarmed(8, 100.0);
+        assert!(!g.observe_armed(8, 120.0));
+        assert!(!g.observe_armed(8, 100.0));
+        assert!(!g.observe_armed(8, 120.0));
+        assert!(!g.observe_armed(8, 120.0));
+        assert!(!g.tripped());
+    }
+
+    #[test]
+    fn an_unseen_shape_is_not_judged() {
+        // Service time is a function of the rung and live batch. Comparing a
+        // rung-16 tick against a rung-8 baseline would trip on a shape change
+        // and stay silent through real contention at another.
+        let mut g = ContentionGuard::new(5.0, 1);
+        g.observe_disarmed(8, 100.0);
+        assert!(!g.observe_armed(16, 10_000.0));
+        assert!(!g.tripped());
+        // The shape it does know still trips.
+        assert!(g.observe_armed(8, 10_000.0));
+    }
+
+    #[test]
+    fn rearming_keeps_the_baselines() {
+        let mut g = ContentionGuard::new(5.0, 1);
+        g.observe_disarmed(8, 100.0);
+        assert!(g.observe_armed(8, 200.0));
+        g.rearm();
+        assert!(!g.tripped());
+        // The baseline describes the machine, not the episode.
+        assert!(g.observe_armed(8, 200.0));
+    }
+}

--- a/crates/plowrt/src/sched/mod.rs
+++ b/crates/plowrt/src/sched/mod.rs
@@ -2,6 +2,11 @@
 
 pub mod admission;
 pub mod batching;
+/// Queue-driven CPU prefill: whether a waiting request's prompt head runs on
+/// the host, how long it may be, and when contention disarms the pool.
+// Allowed dead until the head pool drives it.
+#[allow(dead_code)]
+pub mod het;
 pub mod mdq;
 pub mod multistep;
 pub mod prefill;

--- a/crates/plowrt/src/serve/engine.rs
+++ b/crates/plowrt/src/serve/engine.rs
@@ -587,6 +587,14 @@ mod amd_serve {
         prefill_chunk_rows: u32,
         /// Next slot considered first by opt-in cross-request prefill fairness.
         prefill_turn: usize,
+        /// Rows of this slot's prompt a CPU prefill head already wrote and
+        /// transferred into its KV, consumed once by the next cursor as the
+        /// resume point. 0 = no head.
+        ///
+        /// A head is another source of RESIDENT PREFIX ROWS, which is the thing
+        /// the prefix cache already produces, so it joins at the same seam
+        /// rather than adding a second notion of "already prefilled".
+        head_rows: Vec<u32>,
         /// Width of the decode rung the last dispatch ran, so a rung CHANGE can be logged
         /// once instead of every step. It is the only externally visible evidence that the
         /// ladder is engaging, and a measurement that cannot show that is not a measurement.
@@ -905,6 +913,7 @@ mod amd_serve {
                     rows => rows,
                 },
                 prefill_turn: 0,
+                head_rows: vec![0; batch],
                 last_rung: 0,
                 diagnostics: None,
                 counter_snapshot_dir,
@@ -1233,10 +1242,24 @@ mod amd_serve {
                 if resume == 0 {
                     self.invalidate_prefix(slot);
                 }
+                // A CPU head's rows are resident like a cache hit's, and are
+                // consumed exactly once. Taken only when it beats what the
+                // prefix cache found, so the two never fight over the resume
+                // point; `begin_slot` above has already cleared the slot, which
+                // is why the head is transferred AFTER that call, not before.
+                let head = std::mem::take(&mut self.head_rows[slot]).min(n.saturating_sub(1));
+                let resume = resume.max(head);
                 let max_bucket = self.prefill_chunk_rows.min(tick_max_bucket);
                 let g = &mut self.ranks;
                 let (steps, snap_after) = {
-                    if resume > 0 {
+                    if head > 0 && head >= resume {
+                        // NO `restore_carried`: a head writes append-only KV and
+                        // there is no prefix snapshot behind it. A model with
+                        // carried recurrent state cannot take a head at all —
+                        // `serve::head` refuses it at load — so there is nothing
+                        // to restore rather than something being skipped.
+                        (g.plan_span_at_most(head, n, max_bucket)?, None)
+                    } else if resume > 0 {
                         g.restore_carried(slot)?;
                         (g.plan_span_at_most(resume, n, max_bucket)?, None)
                     } else if arm > 0 {
@@ -1758,6 +1781,29 @@ mod amd_serve {
                 }
             }
             Ok(finishing)
+        }
+
+        /// Hand a CPU prefill head's rows to `slot`: their KV is already in the
+        /// slot's caches, so the next cursor starts at `rows` instead of 0.
+        ///
+        /// Call AFTER writing the rows and BEFORE the slot's next prefill, and
+        /// only on a slot with no cursor in flight — a head is a fresh
+        /// request's prefix, never a splice into a prefill already running.
+        pub fn attach_head(&mut self, slot: usize, rows: u32) -> Result<()> {
+            self.check_slot(slot)?;
+            if self.pf[slot].is_some() || self.live[slot] {
+                return Err(RuntimeError::Rejected(format!(
+                    "slot {slot} is mid-prefill or live; a head attaches to a fresh slot"
+                )));
+            }
+            if rows as usize >= self.max_ctx {
+                return Err(RuntimeError::ContextLength(format!(
+                    "head of {rows} rows against a compiled context of {}",
+                    self.max_ctx
+                )));
+            }
+            self.head_rows[slot] = rows;
+            Ok(())
         }
 
         /// Rows completed by a request whose chunked prefill is still active.

--- a/crates/plowrt/src/serve/head.rs
+++ b/crates/plowrt/src/serve/head.rs
@@ -1,0 +1,274 @@
+//! The CPU prefill-head pool: the twin packet, the cores it is allowed, and a
+//! head that can be abandoned the moment the device is ready for the request.
+//!
+//! ## Placement is inherited, not re-implemented
+//!
+//! The pool's workers are placed by giving [`CpuEngine::load`] a **restricted
+//! topology** — only the cores [`crate::exec::affinity::plan`] reserved for
+//! heads — so `WorkerPool` pins each worker inside the reservation using the
+//! machinery it already has, and nothing in `exec::cpu::workers` changes.
+//!
+//! `SCHED_IDLE` comes the same way. Linux `pthread_create` defaults to
+//! `PTHREAD_INHERIT_SCHED`, so a thread inherits its creator's scheduling
+//! policy; loading the engine from a bootstrap thread that has already put
+//! itself on `SCHED_IDLE` puts every worker there too. **That inheritance is
+//! load-bearing**: without it a head thread can preempt the engine thread
+//! wherever the two masks overlap, which is the one thing this design must not
+//! do. It is asserted after the pool is up rather than assumed.
+//!
+//! Neither mechanism bounds MEMORY BANDWIDTH — an idle-priority thread that is
+//! running still saturates the memory controllers — which is why the pool's
+//! width is a budget and the contention guard watches service time.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::exec::cpu::engine::{next_chunk, CpuEngine, CpuEngineOpts};
+use crate::exec::cpu::topology::{Core, Topology};
+use crate::exec::kv_handoff::{self, CopySpan};
+use crate::exec::kvrow::{self, KvSlotTensor};
+use crate::{Result, RuntimeError};
+
+/// Why a head stopped short of the rows it was asked for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HeadEnd {
+    /// Every requested row is prefilled and its KV is ready to hand over.
+    Complete,
+    /// The device wanted the request before the head finished. Rows already
+    /// covered are still valid — the frontier is where it stopped.
+    Abandoned,
+}
+
+/// A finished (or abandoned) head.
+#[derive(Clone, Copy, Debug)]
+pub struct Head {
+    pub rows: u32,
+    pub end: HeadEnd,
+}
+
+pub struct HeadPool {
+    eng: CpuEngine,
+    /// The twin's transferable caches, in the order the digest hashes them.
+    contract: Vec<KvSlotTensor>,
+    digest: String,
+    pools: Vec<(String, u32)>,
+    rows_per_slot: u32,
+    /// Compiled prefill buckets `(program, rows)` — the abandon granularity.
+    buckets: Vec<(usize, u32)>,
+    slots: usize,
+}
+
+impl HeadPool {
+    /// Load the twin onto `cores`.
+    ///
+    /// Call from a thread that has already set its own affinity and
+    /// `SCHED_IDLE` (see the module note): the worker threads inherit both.
+    pub fn load(
+        twin: &Path,
+        checkpoint: &Path,
+        opts: &CpuEngineOpts,
+        cores: &[u32],
+    ) -> Result<HeadPool> {
+        if cores.is_empty() {
+            return Err(RuntimeError::Rejected(
+                "no cores reserved for prefill heads; set --het-cores or --het-reserve-cores"
+                    .into(),
+            ));
+        }
+        let mut opts = opts.clone();
+        opts.topology = Some(restrict(&Topology::detect(), cores));
+        let eng = CpuEngine::load(twin, checkpoint, &opts)?;
+
+        let blob = &eng.model().blob;
+        let batch = eng.batch() as u32;
+        let contract = kvrow::kv_slot_tensors(blob, batch)?;
+        if contract.is_empty() {
+            return Err(RuntimeError::Device(
+                "CPU twin declares no transferable KV cache; nothing to hand over".into(),
+            ));
+        }
+        let digest = kvrow::kv_contract_digest(&contract);
+
+        // Every prefill program the head may run has to be addressable as row
+        // ranges, and the check is per program because a packet can reach the
+        // caches through more than one.
+        let names: Vec<String> = blob.tensors.iter().map(|t| t.name.clone()).collect();
+        let mut pools = Vec::new();
+        for p in &blob.progs {
+            kv_handoff::check_seq_major(&p.insts, &names)?;
+            for entry in kv_handoff::pooled_caches(&p.insts, &names) {
+                if !pools.contains(&entry) {
+                    pools.push(entry);
+                }
+            }
+        }
+
+        let buckets = eng.prefill_buckets();
+        if buckets.is_empty() {
+            return Err(RuntimeError::Device(
+                "CPU twin has no prefill program; it cannot run a head".into(),
+            ));
+        }
+        let rows_per_slot = eng.max_ctx() as u32;
+        let slots = eng.batch();
+        tracing::info!(
+            cores = cores.len(),
+            slots,
+            rows_per_slot,
+            caches = contract.len(),
+            pooled = pools.len(),
+            kv_contract = %digest,
+            "CPU prefill head pool ready"
+        );
+        Ok(HeadPool {
+            eng,
+            contract,
+            digest,
+            pools,
+            rows_per_slot,
+            buckets,
+            slots,
+        })
+    }
+
+    /// The twin's KV contract; the device engine's must equal it.
+    pub fn kv_contract(&self) -> &str {
+        &self.digest
+    }
+
+    pub fn slots(&self) -> usize {
+        self.slots
+    }
+
+    /// Prefill `prompt[..rows]` into head slot `slot`, checking `cancel`
+    /// between chunks.
+    ///
+    /// Returns how many rows are actually covered. **A cancelled head is not a
+    /// failed one**: the rows it did cover are complete and their KV is
+    /// transferable, so the caller may hand over the shorter prefix or drop it.
+    /// Chunk granularity is the twin's own bucket ladder, which is why the twin
+    /// is emitted with small rungs — it sets how promptly the device can take
+    /// the request back.
+    pub fn run(
+        &mut self,
+        slot: usize,
+        prompt: &[u32],
+        rows: u32,
+        cancel: &AtomicBool,
+    ) -> Result<Head> {
+        if slot >= self.slots {
+            return Err(RuntimeError::Rejected(format!(
+                "head slot {slot} past the twin's {} slots",
+                self.slots
+            )));
+        }
+        let rows = rows.min(prompt.len() as u32).min(self.rows_per_slot);
+        if rows == 0 {
+            return Ok(Head {
+                rows: 0,
+                end: HeadEnd::Complete,
+            });
+        }
+        let mut done = 0u32;
+        while done < rows {
+            if cancel.load(Ordering::Relaxed) {
+                return Ok(Head {
+                    rows: done,
+                    end: HeadEnd::Abandoned,
+                });
+            }
+            let ch = next_chunk(&self.buckets, rows, done, u32::MAX);
+            self.eng.prefill_slot_chunk(slot, &prompt[..rows as usize], ch)?;
+            done += ch.clen;
+        }
+        Ok(Head {
+            rows: done,
+            end: HeadEnd::Complete,
+        })
+    }
+
+    /// Plan the copies handing `rows` of head slot `src` to device slot `dst`.
+    pub fn plan(&self, src: u32, dst: u32, rows: u32) -> Result<Vec<CopySpan>> {
+        kv_handoff::plan(
+            &self.contract,
+            self.rows_per_slot,
+            &self.pools,
+            src,
+            dst,
+            rows,
+        )
+    }
+
+    /// The source bytes for one planned copy, read straight out of the twin's
+    /// host tensor.
+    pub fn source(&self, span: &CopySpan) -> Result<&[u8]> {
+        self.eng
+            .model()
+            .tensor_range(span.handle, span.src_off, span.bytes)
+    }
+}
+
+/// A topology restricted to `cores` — the reservation the head pool may use.
+///
+/// Whole physical cores with their SMT siblings, because that is what the
+/// reservation is cut in: keeping a core whose sibling is outside the set would
+/// put a head on the same execution resources as a serving thread.
+fn restrict(topo: &Topology, cores: &[u32]) -> Topology {
+    let keep: Vec<Core> = topo
+        .cores
+        .iter()
+        .filter(|c| c.siblings.iter().all(|s| cores.contains(s)))
+        .cloned()
+        .collect();
+    let mut nodes: Vec<u32> = keep.iter().map(|c| c.node).collect();
+    nodes.sort_unstable();
+    nodes.dedup();
+    Topology {
+        cores: keep,
+        nodes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn core(cpu: u32, node: u32, siblings: &[u32]) -> Core {
+        Core {
+            cpu,
+            node,
+            siblings: siblings.to_vec(),
+        }
+    }
+
+    fn smt_box() -> Topology {
+        Topology {
+            cores: (0..4).map(|i| core(i, i / 2, &[i, i + 4])).collect(),
+            nodes: vec![0, 1],
+        }
+    }
+
+    #[test]
+    fn a_restricted_topology_keeps_only_whole_reserved_cores() {
+        let t = restrict(&smt_box(), &[2, 6, 3, 7]);
+        assert_eq!(t.cores.len(), 2);
+        assert_eq!(t.cores[0].cpu, 2);
+        assert_eq!(t.nodes, vec![1]);
+    }
+
+    #[test]
+    fn a_core_with_a_sibling_outside_the_reservation_is_dropped() {
+        // Half a core is not a reservation: the sibling would share execution
+        // resources with whatever holds the other thread.
+        let t = restrict(&smt_box(), &[2, 3, 7]);
+        assert_eq!(t.cores.len(), 1, "only core 3 has both siblings reserved");
+        assert_eq!(t.cores[0].cpu, 3);
+    }
+
+    #[test]
+    fn an_empty_reservation_restricts_to_nothing() {
+        let t = restrict(&smt_box(), &[]);
+        assert!(t.cores.is_empty());
+        assert!(t.nodes.is_empty());
+    }
+}

--- a/crates/plowrt/src/serve/head.rs
+++ b/crates/plowrt/src/serve/head.rs
@@ -128,6 +128,31 @@ impl HeadPool {
                     .into(),
             ));
         }
+        // REFUSE ON THE PACKET BEFORE PAYING FOR THE WEIGHTS. Whether a model's
+        // caches are addressable as row ranges is a property of the packet
+        // alone, and a twin that cannot hand over should say so in
+        // milliseconds — not after a 22 GiB checkpoint load, which is what the
+        // first cut of this did and what a Gemma-4-12B bundle actually costs.
+        //
+        // Every prefill program is checked, not just one: a packet can reach
+        // the caches through more than one program.
+        let bytes = std::fs::read(twin).map_err(|e| {
+            RuntimeError::Device(format!("CPU twin {}: {e}", twin.display()))
+        })?;
+        let blob = crate::asset::devblob::DevBlob::parse(&bytes)?;
+        let names: Vec<String> = blob.tensors.iter().map(|t| t.name.clone()).collect();
+        let mut pools = Vec::new();
+        for p in &blob.progs {
+            kv_handoff::check_seq_major(&p.insts, &names)?;
+            for entry in kv_handoff::pooled_caches(&p.insts, &names) {
+                if !pools.contains(&entry) {
+                    pools.push(entry);
+                }
+            }
+        }
+        drop(blob);
+        drop(bytes);
+
         let mut opts = opts.clone();
         opts.topology = Some(restrict(&Topology::detect(), cores));
         let eng = CpuEngine::load(twin, checkpoint, &opts)?;
@@ -141,20 +166,6 @@ impl HeadPool {
             ));
         }
         let digest = kvrow::kv_contract_digest(&contract);
-
-        // Every prefill program the head may run has to be addressable as row
-        // ranges, and the check is per program because a packet can reach the
-        // caches through more than one.
-        let names: Vec<String> = blob.tensors.iter().map(|t| t.name.clone()).collect();
-        let mut pools = Vec::new();
-        for p in &blob.progs {
-            kv_handoff::check_seq_major(&p.insts, &names)?;
-            for entry in kv_handoff::pooled_caches(&p.insts, &names) {
-                if !pools.contains(&entry) {
-                    pools.push(entry);
-                }
-            }
-        }
 
         let buckets = eng.prefill_buckets();
         if buckets.is_empty() {

--- a/crates/plowrt/src/serve/head.rs
+++ b/crates/plowrt/src/serve/head.rs
@@ -20,10 +20,11 @@
 //! running still saturates the memory controllers — which is why the pool's
 //! width is a budget and the contention guard watches service time.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::exec::cpu::engine::{next_chunk, CpuEngine, CpuEngineOpts};
+use crate::exec::cpu::ffi::Isa;
 use crate::exec::cpu::topology::{Core, Topology};
 use crate::exec::kv_handoff::{self, CopySpan};
 use crate::exec::kvrow::{self, KvSlotTensor};
@@ -44,6 +45,58 @@ pub enum HeadEnd {
 pub struct Head {
     pub rows: u32,
     pub end: HeadEnd,
+}
+
+/// Where a head's twin packet comes from, and whether this host can run one.
+///
+/// A twin is another VARIANT of the same model — same context, a target the CPU
+/// interpreter accepts — so selecting one is variant selection and belongs to
+/// whatever pulled the bundle. This resolves the packet inside the bundle that
+/// selection materialised: `--het-twin` names it outright, otherwise the
+/// conventional `cpu-twin/model.pkt` beside the device packet.
+///
+/// `None` is the ordinary answer on a bundle that carries no twin, and it means
+/// heads are off for that model. Not an error: a device packet without a twin
+/// is a complete, servable bundle.
+pub fn resolve_twin(assets: &Path, configured: Option<&str>) -> Option<PathBuf> {
+    if let Some(p) = configured {
+        let p = PathBuf::from(p);
+        // A directory names a bundle; a file names the packet in one.
+        let pkt = if p.is_dir() { p.join("model.pkt") } else { p };
+        return pkt.is_file().then_some(pkt);
+    }
+    let conventional = assets.join("cpu-twin").join("model.pkt");
+    conventional.is_file().then_some(conventional)
+}
+
+/// Whether this host can run prefill heads at all, independent of load.
+///
+/// Two gates, and both are about not making serving worse:
+///
+/// * **A vector tier.** A scalar CPU prefill of a serving-sized model is slow
+///   enough that no queue hides it, so the head would be abandoned every time
+///   and the pool would only ever cost cores. AVX-512 or AMX is the floor.
+/// * **A reservation.** With no cores reserved a head runs on the serving
+///   path's, which is the one thing this must not do.
+///
+/// Returns the reason rather than a bool: a host that cannot run heads should
+/// say why once at load, not silently serve as though the feature were off.
+pub fn host_supports_heads(isa: Isa, reserved_cores: usize) -> std::result::Result<(), String> {
+    if matches!(isa, Isa::Scalar) {
+        return Err(
+            "CPU prefill heads need the AVX-512 or AMX tier; this host probed scalar, where a \
+             head is slower than any queue it could hide in"
+                .into(),
+        );
+    }
+    if reserved_cores == 0 {
+        return Err(
+            "no cores reserved for prefill heads; set --het-reserve-cores or --het-cores, or a \
+             head would run on the serving path's cores"
+                .into(),
+        );
+    }
+    Ok(())
 }
 
 pub struct HeadPool {
@@ -246,6 +299,71 @@ mod tests {
             cores: (0..4).map(|i| core(i, i / 2, &[i, i + 4])).collect(),
             nodes: vec![0, 1],
         }
+    }
+
+    #[test]
+    fn a_bundle_without_a_twin_simply_has_no_heads() {
+        // Not an error: a device packet with no twin is a complete bundle.
+        let dir = std::env::temp_dir().join("plow_head_none");
+        let _ = std::fs::create_dir_all(&dir);
+        assert_eq!(resolve_twin(&dir, None), None);
+    }
+
+    #[test]
+    fn the_conventional_location_is_beside_the_device_packet() {
+        let dir = std::env::temp_dir().join("plow_head_conv");
+        let twin = dir.join("cpu-twin");
+        std::fs::create_dir_all(&twin).unwrap();
+        let pkt = twin.join("model.pkt");
+        std::fs::write(&pkt, b"x").unwrap();
+        assert_eq!(resolve_twin(&dir, None), Some(pkt));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_configured_directory_names_a_bundle_and_a_file_names_a_packet() {
+        let dir = std::env::temp_dir().join("plow_head_cfg");
+        std::fs::create_dir_all(&dir).unwrap();
+        let pkt = dir.join("model.pkt");
+        std::fs::write(&pkt, b"x").unwrap();
+        assert_eq!(
+            resolve_twin(Path::new("/nonexistent"), Some(dir.to_str().unwrap())),
+            Some(pkt.clone())
+        );
+        assert_eq!(
+            resolve_twin(Path::new("/nonexistent"), Some(pkt.to_str().unwrap())),
+            Some(pkt)
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_configured_twin_that_is_not_there_resolves_to_nothing() {
+        // Reported as "no heads" by the caller rather than papered over with
+        // the conventional path, which would serve a twin the operator did not
+        // ask for.
+        assert_eq!(
+            resolve_twin(Path::new("/nonexistent"), Some("/nonexistent/model.pkt")),
+            None
+        );
+    }
+
+    #[test]
+    fn a_scalar_host_cannot_run_heads() {
+        let err = host_supports_heads(Isa::Scalar, 8).unwrap_err();
+        assert!(err.contains("AVX-512 or AMX"), "{err}");
+    }
+
+    #[test]
+    fn no_reservation_means_no_heads() {
+        let err = host_supports_heads(Isa::Avx512, 0).unwrap_err();
+        assert!(err.contains("no cores reserved"), "{err}");
+    }
+
+    #[test]
+    fn a_vector_host_with_a_reservation_can() {
+        assert!(host_supports_heads(Isa::Avx512, 4).is_ok());
+        assert!(host_supports_heads(Isa::Amx, 4).is_ok());
     }
 
     #[test]

--- a/crates/plowrt/src/serve/mod.rs
+++ b/crates/plowrt/src/serve/mod.rs
@@ -11,6 +11,11 @@ pub mod cpu_serve;
 /// the seam that lets `serve` stop being CUDA-only.
 #[cfg(any(feature = "cuda", feature = "hsa", feature = "cpu"))]
 pub mod engine;
+/// The CPU prefill-head pool: the twin packet and the cores reserved for it.
+// Allowed dead until the mux drives it.
+#[cfg(feature = "cpu")]
+#[allow(dead_code)]
+pub mod head;
 #[cfg(feature = "cuda")]
 pub mod manager;
 pub mod models;


### PR DESCRIPTION
## Read this first: phase 0 measured, and it says stop for dense models

This branch implements queue-driven CPU prefill offload — while the GPU queue is full, a waiting
request's prompt head prefills on idle host cores and its KV rows hand off to the device. **It then
measures whether that pays, and for a dense model it does not.**

Gemma-4-12B, same box, same bundle geometry (`--max-ctx 2048`, `[128, 512, 1024]` ladder, bf16 KV).
GPU is `plowrt bench --prefill-sweep` on MI300X through the production mux; CPU is `cpu_bench` on
2x EPYC 9654 at 96 threads, AVX-512:

| rows | GPU TTFT p50 | CPU TTFT | ratio |
|---:|---:|---:|---:|
| 32 | 38.6 ms | 775.7 ms | 17x |
| 128 | 40.8 ms | 2129.7 ms | 52x |
| 512 | 71.1 ms | 5486.7 ms | 77x |

```
GPU ~  30.7 ms + 0.0790 ms/row
CPU ~ 461.6 ms + 9.815  ms/row      -> 124x per row
```

**A 28-row head spends 736 ms of CPU wall time to remove 2.2 ms of GPU work (333:1).** Sustained
CPU prefill is 0.8% of the GPU's. The queueing argument this design rests on needs an offload
fraction where `rho -> rho(1-f)` matters; `f = 0.008` does not. The plan's own phase-0 gate said
"if it is small, stop" — it is small.

**What is NOT settled:** the design's actual target is a big MoE, which is unmeasured. GPU prefill
is less efficient per row there (GLM-5.3 fits ~0.209 ms/row, 2.6x Gemma's), but the CPU almost
certainly degrades more — a 355B-A32B pass streams ~700 GB against this 12B's 22 GB. Expect the
verdict to hold or worsen; that measurement is now cheap because both harnesses work.

## So why merge it?

Everything here is **off by default and inert**: no mux calls any of it, and with `--het-*` unset
the serving path is byte-identical to main. The argument for landing rather than dropping is that
the measurement apparatus and the refusals are the reusable part, and re-deriving them costs more
than carrying them. **The argument for dropping is real too** — ~1,800 lines of `allow(dead_code)`
machinery for a feature whose economics just failed. Reviewer's call; I would not merge this
silently on the strength of the code alone.

## What is here

| area | what |
|---|---|
| `plow-asset/kv_contract.rs` | KV-geometry digest binding a device packet to a CPU twin |
| `exec/affinity.rs` | whole-core reservation, `SCHED_IDLE`, engine-thread pinning |
| `exec/kv_handoff.rs` | row-range -> byte-copy planning; head-major and pooled-cache refusals |
| `sched/het.rs` | queue-driven head budget, arming hysteresis, contention guard |
| `serve/head.rs` | head pool: restricted topology, abandonable head, twin resolution, host gate |
| `exec/amd.rs`, `serve/engine.rs` | `write_kv_rows`, `attach_head` (joins the prefix-cache resume seam) |
| `examples/head_probe.rs` | "can this bundle serve heads, and if not why" |

**plowc and devgen are untouched.** An earlier revision added a `--cpu-twin` emit mode; that was
reverted and the commits dropped from history. A twin is another *variant* of a model plowc already
compiles, so selecting one belongs to the distribution, and the KV contract is checked at load
against the two packets actually about to be used together.

## Three things the work found

1. **The rung snap in the plan cannot fire.** Device cost is monotone non-increasing in rows
   removed, so the largest affordable head is never a worse cover. Removed; alignment is subsumed.
2. **Divisibility does not detect a pooled cache.** `(ctx/pool) x width` stays divisible by `ctx`
   whenever `pool` divides `width`. The first transfer planner silently copied a quarter of the
   bytes a 4-row head owed; its own test caught it. Pool size now comes off `DsaPoolCompress.i[1]`.
3. **The handoff is MLA-only.** Gemma-4 writes `kv.0.k` with a nonzero KV ring stride, so its
   caches are head-major and `HeadPool::load` refuses the bundle by name in 0.19 s. Dense GQA
   (Gemma, Llama, Qwen) is out; MLA (GLM, DeepSeek, Kimi) is in.

## Not wired, deliberately

The mux does not call any of this. Wiring it needs the wait queue made addressable: arrivals sit in
a bounded MPSC that the tick drains only into idle slots, so a queued-but-unadmitted request has no
handle to attach a head to. The fix (drain into an owned `VecDeque`) also moves where requests are
rejected under overload, which changes admission for every request — it wants a live concurrency
test, not a compile-clean diff.

## Verification

`cargo check --workspace` clean; `cpu`, `hsa`, `hsa,cpu` and default features all build clean.
plowrt lib 401 pass, plow-asset 119 pass. Ran on real hardware: Gemma-4-12B bundles emitted and
benchmarked on CPU and on MI300X.

Pre-existing, not fixed: `tests/token_batch_tail.rs:342` calls `WorkerPool::spawn` with 6 arguments
against a 7-argument signature. Separately, the stale-object errors in `exec::amd` say "Rebuild it
with `scripts/build_gfx950.sh`" while reporting a **gfx942** object; the two scripts are
deliberately different and following the message yields an object that fails symbol resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5qeFdENLq1vzLnxNMvyVs
